### PR TITLE
Experimental WASM target

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -335,7 +335,60 @@ cmake --build build/windows-sdl-release --config Release
 | `macos-release` | macOS | Release |
 | `windows-sdl-debug` | Windows | Debug (SDL3) |
 | `windows-sdl-release` | Windows | Release (SDL3) |
+| `wasm-debug` | Emscripten/WebAssembly | Debug |
+| `wasm-release` | Emscripten/WebAssembly | Release |
 | `windows-libs-only` | Windows | Core libraries only (no frontend) |
+
+### WebAssembly Build (Emscripten, experimental)
+
+This target cross-compiles AltirraSDL to WebAssembly for browser-based
+testing and development.
+
+Prerequisites:
+
+- Emscripten SDK installed (tested with 5.0.6)
+- `emsdk_env.sh` available in your shell
+
+Build using presets:
+
+```bash
+# from repo root
+source ~/emsdk/emsdk_env.sh
+
+cmake --preset wasm-debug
+cmake --build --preset wasm-debug -- -j$(nproc)
+```
+
+Output files:
+
+- `build/wasm-debug/src/AltirraSDL/AltirraSDL.js`
+- `build/wasm-debug/src/AltirraSDL/AltirraSDL.wasm`
+- `build/wasm-debug/src/AltirraSDL/index.html` (auto-generated shell page)
+
+Notes:
+
+- Current WASM smoke boot embeds `wizard.xex` into the virtual filesystem.
+- WASM currently uses the SDL renderer path (no direct OpenGL backend).
+- Netplay and bridge server are forced off in `ALTIRRA_WASM` builds.
+
+Run in a local HTTP server (required for browser WASM):
+
+```bash
+source ~/emsdk/emsdk_env.sh
+cd build/wasm-debug/src/AltirraSDL
+emrun --no_browser --port 8080 .
+```
+
+Then open:
+
+- `http://localhost:8080/index.html`
+
+Troubleshooting:
+
+- If browser output shows an exception-catching abort, verify link flags
+    include `-sNO_DISABLE_EXCEPTION_CATCHING=1`.
+- If keyboard joystick mapping appears inactive on first run, clear or
+    remove stale input selections in `~/.config/altirra/settings.ini`.
 
 ### Package Target
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,23 @@ endif()
 # required so feature parity with the Windows build is the default.
 option(ALTIRRA_SKIP_SDL3_IMAGE "Build without SDL3_image (disables image load/save)" OFF)
 
+# ALTIRRA_WASM — enable browser/WebAssembly build mode.
+#
+# This switch is intended for Emscripten toolchain builds only. It does
+# not select the toolchain itself; configure with emcmake / Emscripten
+# presets and then use this flag to gate Altirra-specific feature toggles.
+option(ALTIRRA_WASM "Enable WebAssembly/browser build mode (Emscripten)" OFF)
+if(ALTIRRA_WASM)
+    if(NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+        message(FATAL_ERROR
+            "ALTIRRA_WASM=ON requires the Emscripten toolchain.\n"
+            "Configure with emcmake (or an Emscripten preset) and rerun CMake.")
+    endif()
+
+    message(STATUS "ALTIRRA_WASM=ON (Emscripten web build mode)")
+    add_compile_definitions(ALTIRRA_WASM=1)
+endif()
+
 # Platform compile definitions — belt-and-suspenders with vdtypes.h auto-detect
 if(WIN32)
     add_compile_definitions(VD_OS_WINDOWS=1)
@@ -365,6 +382,10 @@ if(ALTIRRA_SDL3)
     # (librashader.so/.dll/.dylib) is loaded at runtime via dlopen —
     # no link-time dependency.
     option(ENABLE_LIBRASHADER "Enable librashader shader preset support" ON)
+    if(ALTIRRA_WASM AND ENABLE_LIBRASHADER)
+        message(WARNING "ENABLE_LIBRASHADER is not supported for ALTIRRA_WASM; forcing OFF.")
+        set(ENABLE_LIBRASHADER OFF CACHE BOOL "Enable librashader shader preset support" FORCE)
+    endif()
     if(ENABLE_LIBRASHADER)
         FetchContent_Declare(
             librashader_headers
@@ -646,9 +667,17 @@ static inline void *_librashader_dlopen_macos(void) {
         ${imgui_SOURCE_DIR}/imgui_widgets.cpp
         ${imgui_SOURCE_DIR}/backends/imgui_impl_sdl3.cpp
         ${imgui_SOURCE_DIR}/backends/imgui_impl_sdlrenderer3.cpp
-        ${imgui_SOURCE_DIR}/backends/imgui_impl_opengl3.cpp
         ${imgui_SOURCE_DIR}/misc/cpp/imgui_stdlib.cpp
     )
+    # On WASM the GL display backend is excluded — only the SDL_Renderer path
+    # is used.  imgui_impl_opengl3.cpp must NOT be compiled: its direct
+    # glXxx calls conflict with the Emscripten WebGL stubs compiled into
+    # SDL3 (symbol type mismatch at wasm-ld).
+    if(NOT ALTIRRA_WASM)
+        target_sources(imgui PRIVATE
+            ${imgui_SOURCE_DIR}/backends/imgui_impl_opengl3.cpp
+        )
+    endif()
     target_include_directories(imgui PUBLIC
         ${imgui_SOURCE_DIR}
         ${imgui_SOURCE_DIR}/backends
@@ -664,7 +693,7 @@ static inline void *_librashader_dlopen_macos(void) {
     # points that don't exist in GLES (glPolygonMode etc.) and link-fail
     # against system libGLESv3.  On desktop the default (Desktop GL) path
     # is correct.
-    if(ANDROID)
+    if(ANDROID OR ALTIRRA_WASM)
         target_compile_definitions(imgui PUBLIC IMGUI_IMPL_OPENGL_ES3)
     endif()
     # Suppress warnings in third-party code

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -15,6 +15,16 @@
             }
         },
         {
+            "name": "emscripten-base",
+            "hidden": true,
+            "inherits": "base",
+            "cacheVariables": {
+                "CMAKE_TOOLCHAIN_FILE": "$env{EMSDK}/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake",
+                "ALTIRRA_SDL3": "ON",
+                "ALTIRRA_WASM": "ON"
+            }
+        },
+        {
             "name": "linux-debug",
             "displayName": "Linux Debug (SDL3)",
             "inherits": "base",
@@ -119,6 +129,32 @@
                 "lhs": "${hostSystemName}",
                 "rhs": "Windows"
             }
+        },
+        {
+            "name": "wasm-debug",
+            "displayName": "WebAssembly Debug (Emscripten)",
+            "inherits": "emscripten-base",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug"
+            },
+            "condition": {
+                "type": "notEquals",
+                "lhs": "$env{EMSDK}",
+                "rhs": ""
+            }
+        },
+        {
+            "name": "wasm-release",
+            "displayName": "WebAssembly Release (Emscripten)",
+            "inherits": "emscripten-base",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release"
+            },
+            "condition": {
+                "type": "notEquals",
+                "lhs": "$env{EMSDK}",
+                "rhs": ""
+            }
         }
     ],
     "buildPresets": [
@@ -149,6 +185,14 @@
         {
             "name": "windows-libs-only",
             "configurePreset": "windows-libs-only"
+        },
+        {
+            "name": "wasm-debug",
+            "configurePreset": "wasm-debug"
+        },
+        {
+            "name": "wasm-release",
+            "configurePreset": "wasm-release"
         }
     ]
 }

--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ upstream does is taken away — and most of them are only interesting
   Windows `.sln` build is still preserved upstream-identical; this
   fork contributes the SDL3 + Dear ImGui frontend that lets the same
   emulation core run everywhere SDL3 does.
+- **Experimental WebAssembly target (Emscripten)** for browser-based
+  smoke testing and debugging. This currently focuses on development
+  workflow rather than end-user packaging. The build emits
+  `AltirraSDL.js/.wasm` and an auto-generated `index.html` shell for
+  quick local testing.
 - **Portable settings** stored as a plain INI at
   `~/.config/altirra/settings.ini` (same format as Windows portable
   mode). No registry, no hidden state.
@@ -215,7 +220,8 @@ Altirra is licensed under the **GNU General Public License v2 (GPLv2)**, with a 
 ## Documentation
 
 - [BUILD.md](BUILD.md) — building AltirraSDL from source on Linux,
-  macOS, Windows (CMake) and Android.
+  macOS, Windows (CMake), Android, and experimental WebAssembly
+  (Emscripten).
 - [NETPLAY.md](NETPLAY.md) — playing online: host a game, join a
   game, point at a different lobby, and step-by-step instructions
   for running your own lobby server (localhost, Docker, VPS with

--- a/src/ATCore/source/fft_scalar.cpp
+++ b/src/ATCore/source/fft_scalar.cpp
@@ -166,7 +166,7 @@ void ATFFT_DIT_Radix8_Scalar(float *dst0, const float *y0, const uint32 *order0,
 	}
 }
 
-void ATFFT_DIT_R2C_Scalar(float *dst0, const float *src0, const float *w, int N) {
+void ATFFT_DIT_R2C_Scalar(float *dst0, const float *src0, const float *w, size_t N) {
 	float *__restrict dst = dst0;
 	const float *__restrict src = src0;
 	const float *__restrict w2 = w + 2;
@@ -176,7 +176,7 @@ void ATFFT_DIT_R2C_Scalar(float *dst0, const float *src0, const float *w, int N)
 	dst[0] = rz + iz;
 	dst[1] = rz - iz;
 
-	for(int i=2; i<N/2; i += 2) {
+	for(int i=2; i<(int)(N/2); i += 2) {
 		float r0 = src[i];
 		float i0 = src[i+1];
 		float r1 = src[N-i];
@@ -205,7 +205,7 @@ void ATFFT_DIT_R2C_Scalar(float *dst0, const float *src0, const float *w, int N)
 	dst[N/2+1] = -src[N/2+1];
 }
 
-void ATFFT_DIF_C2R_Scalar(float *dst0, float *x, const float *w, int N) {
+void ATFFT_DIF_C2R_Scalar(float *dst0, const float *x, const float *w, size_t N) {
 	float *__restrict dst = dst0;
 
 	float rz = x[0];
@@ -218,7 +218,7 @@ void ATFFT_DIF_C2R_Scalar(float *dst0, float *x, const float *w, int N) {
 
 	w += 2;
 
-	for(int i=2; i<N/2; i += 2) {
+	for(int i=2; i<(int)(N/2); i += 2) {
 		float r0 = x[i];
 		float i0 = x[i+1];
 		float r1 = x[N-i];

--- a/src/ATIO/source/cassettedecoder.cpp
+++ b/src/ATIO/source/cassettedecoder.cpp
@@ -353,7 +353,7 @@ void ATCassetteDecoderTurbo::Process(const sint16 *samples, uint32 n, float *ade
 #else
 	[[maybe_unused]] float hpf[16];
 
-	if constexpr (T_PreFilter == PrefilterType::HP_FIR) {
+	if constexpr (T_PreFilter == PreFilterType::HP_FIR) {
 		memcpy(hpf, mHPFWindow, sizeof hpf);
 	}
 #endif

--- a/src/Altirra/source/inputmanager.cpp
+++ b/src/Altirra/source/inputmanager.cpp
@@ -1238,6 +1238,7 @@ void ATInputManager::LoadSelections(VDRegistryKey& key, ATInputControllerType de
 
 	bool foundActive = true;
 	bool foundQuick = true;
+	bool hasActiveSelection = false;
 
 	for(int mapType = 0; mapType < 2; ++mapType) {
 		VDStringW mapNames;
@@ -1257,6 +1258,9 @@ void ATInputManager::LoadSelections(VDRegistryKey& key, ATInputControllerType de
 				token = parser;
 				parser.clear();
 			}
+
+			if (!token.empty() && mapType == 0)
+				hasActiveSelection = true;
 
 			mapStateLookup[VDStringW(token)] |= (uint8)(1 << mapType);
 		}
@@ -1279,7 +1283,7 @@ void ATInputManager::LoadSelections(VDRegistryKey& key, ATInputControllerType de
 
 	// If there was no setting for active maps, look for the first input map with the specified
 	// default controller type. We sort by name so the result is deterministic.
-	if (!foundActive && defaultControllerType) {
+	if ((!foundActive || !hasActiveSelection) && defaultControllerType) {
 		vdfastvector<ATInputMap *> sortedMaps;
 		sortedMaps.reserve(mInputMaps.size());
 

--- a/src/Altirra/source/settings.cpp
+++ b/src/Altirra/source/settings.cpp
@@ -734,6 +734,10 @@ void ATSettingsExchangeInput(bool write, VDRegistryKey& key) {
 
 		if (g_sim.GetHardwareMode() == kATHardwareMode_5200)
 			defaultController = kATInputControllerType_5200Controller;
+#ifdef ALTIRRA_WASM
+		else
+			defaultController = kATInputControllerType_Joystick;
+#endif
 
 		g_sim.GetInputManager()->LoadSelections(key, defaultController);
 	}

--- a/src/AltirraSDL/CMakeLists.txt
+++ b/src/AltirraSDL/CMakeLists.txt
@@ -50,10 +50,6 @@ target_sources(AltirraSDL PRIVATE
     # --- display/ : SDL display + GL backends + shaders ---
     source/display/display_sdl3.cpp
     source/display/display_backend_sdl.cpp
-    source/display/display_backend_gl33.cpp
-    source/display/gl_funcs.cpp
-    source/display/gl_helpers.cpp
-    source/display/display_librashader.cpp
 
     # --- input/ : SDL input, joystick, touch ---
     source/input/input_sdl3.cpp
@@ -191,15 +187,6 @@ target_sources(AltirraSDL PRIVATE
     source/ui/gamelibrary/game_library.cpp
     source/ui/gamelibrary/game_library_art.cpp
 
-    # --- ui/emotes/ : Online Play communication icons ---
-    source/ui/emotes/emote_assets.cpp
-    source/ui/emotes/emote_overlay.cpp
-    source/ui/emotes/emote_picker.cpp
-    source/ui/emotes/emote_netplay.cpp
-
-    # --- ui/sysconfig/ : Online Play settings page ---
-    source/ui/sysconfig/ui_system_pages_netplay.cpp
-
     # Registry persistence (filtered out by ui* regex, so add explicitly)
     ${CMAKE_SOURCE_DIR}/src/Altirra/source/uiregistry.cpp
 
@@ -241,6 +228,17 @@ target_sources(AltirraSDL PRIVATE
     ${ALTIRRA_ALL_SOURCES}
 )
 
+# GL display backend and helpers — not used on WASM (SDL_Renderer is the only
+# rendering path there; direct GL calls conflict with Emscripten's WebGL stubs).
+if(NOT ALTIRRA_WASM)
+    target_sources(AltirraSDL PRIVATE
+        source/display/display_backend_gl33.cpp
+        source/display/gl_funcs.cpp
+        source/display/gl_helpers.cpp
+        source/display/display_librashader.cpp
+    )
+endif()
+
 # Re-include Win32-specific files that were excluded by the _win32.cpp filter
 # but are needed on the Windows SDL3 build.
 if(WIN32)
@@ -259,6 +257,10 @@ endif()
 # Winsock (ws2_32) propagates transitively from `system` and ATNetworkSockets,
 # so no explicit link is needed on Windows.
 option(ALTIRRA_BRIDGE "Build the AltirraBridge scripting server" ON)
+if(ALTIRRA_WASM AND ALTIRRA_BRIDGE)
+    message(WARNING "ALTIRRA_BRIDGE is not yet supported for ALTIRRA_WASM; forcing OFF.")
+    set(ALTIRRA_BRIDGE OFF CACHE BOOL "Build the AltirraBridge scripting server" FORCE)
+endif()
 if(ALTIRRA_BRIDGE)
     target_sources(AltirraSDL PRIVATE
         source/bridge/bridge_server.cpp
@@ -285,6 +287,10 @@ endif()
 # protocol only; transport, coordinator, lobby client, and UI land in
 # subsequent phases.  Default ON; disable with -DALTIRRA_NETPLAY=OFF.
 option(ALTIRRA_NETPLAY "Build the AltirraSDL netplay module" ON)
+if(ALTIRRA_WASM AND ALTIRRA_NETPLAY)
+    message(WARNING "ALTIRRA_NETPLAY is not yet supported for ALTIRRA_WASM; forcing OFF.")
+    set(ALTIRRA_NETPLAY OFF CACHE BOOL "Build the AltirraSDL netplay module" FORCE)
+endif()
 if(ALTIRRA_NETPLAY)
     target_sources(AltirraSDL PRIVATE
         source/netplay/protocol.cpp
@@ -313,6 +319,15 @@ if(ALTIRRA_NETPLAY)
         source/ui/netplay/ui_netplay_actions.cpp
         source/ui/netplay/ui_netplay_activity.cpp
         source/ui/netplay/ui_netplay.cpp
+
+        # Emote system (icon picker, overlay, netplay send/receive)
+        source/ui/emotes/emote_assets.cpp
+        source/ui/emotes/emote_overlay.cpp
+        source/ui/emotes/emote_picker.cpp
+        source/ui/emotes/emote_netplay.cpp
+
+        # Online Play settings page (references emote/netplay symbols)
+        source/ui/sysconfig/ui_system_pages_netplay.cpp
     )
     if(WIN32)
         target_sources(AltirraSDL PRIVATE
@@ -573,7 +588,7 @@ target_include_directories(AltirraSDL BEFORE PRIVATE
     ${CMAKE_SOURCE_DIR}/src/Altirra/h
 )
 
-if(NOT ANDROID)
+if(NOT ANDROID AND NOT ALTIRRA_WASM)
     find_package(OpenGL REQUIRED)
 endif()
 
@@ -606,9 +621,34 @@ if(NOT ALTIRRA_SKIP_SDL3_IMAGE)
     target_link_libraries(AltirraSDL PRIVATE SDL3_image::SDL3_image)
 endif()
 
-# OpenGL: desktop GL on Linux/macOS/Windows, GLESv3 on Android
+# OpenGL: desktop GL on Linux/macOS/Windows, GLESv3 on Android, and
+# Emscripten/WebGL via link flags in ALTIRRA_WASM mode.
 if(ANDROID)
     target_link_libraries(AltirraSDL PRIVATE GLESv3 EGL android log)
+elseif(ALTIRRA_WASM)
+    set(ALTIRRA_WASM_SMOKE_MEDIA
+        "${CMAKE_SOURCE_DIR}/src/AltirraSDL/AltirraBridge/examples/case_studies/wizard/wizard.xex"
+        CACHE FILEPATH
+        "Bundled media used for wasm smoke boot (embedded into virtual FS)")
+
+    if(EXISTS "${ALTIRRA_WASM_SMOKE_MEDIA}")
+        target_link_options(AltirraSDL PRIVATE
+            "SHELL:--embed-file ${ALTIRRA_WASM_SMOKE_MEDIA}@/media/wizard.xex"
+        )
+        target_compile_definitions(AltirraSDL PRIVATE
+            ALTIRRA_WASM_SMOKE_BOOT_PATH=\"/media/wizard.xex\"
+        )
+    else()
+        message(WARNING
+            "ALTIRRA_WASM_SMOKE_MEDIA not found at '${ALTIRRA_WASM_SMOKE_MEDIA}'. "
+            "Wasm smoke auto-boot will be disabled.")
+    endif()
+
+    target_link_options(AltirraSDL PRIVATE
+        "SHELL:-sUSE_WEBGL2=1"
+        "SHELL:-sASYNCIFY=1"
+        "SHELL:-sALLOW_MEMORY_GROWTH=1"
+    )
 else()
     target_link_libraries(AltirraSDL PRIVATE OpenGL::GL)
 endif()
@@ -733,7 +773,11 @@ elseif(APPLE)
     # [[msvc::no_unique_address]] annotation in vdalloc.h.
     target_compile_options(AltirraSDL PRIVATE -Wno-unknown-attributes)
 elseif(UNIX)
-    target_compile_definitions(AltirraSDL PRIVATE VD_OS_LINUX=1)
+    if(ALTIRRA_WASM)
+        target_compile_definitions(AltirraSDL PRIVATE VD_OS_LINUX=1 ALTIRRA_WASM=1)
+    else()
+        target_compile_definitions(AltirraSDL PRIVATE VD_OS_LINUX=1)
+    endif()
 endif()
 
 # ===========================================================================

--- a/src/AltirraSDL/CMakeLists.txt
+++ b/src/AltirraSDL/CMakeLists.txt
@@ -648,7 +648,17 @@ elseif(ALTIRRA_WASM)
         "SHELL:-sUSE_WEBGL2=1"
         "SHELL:-sASYNCIFY=1"
         "SHELL:-sALLOW_MEMORY_GROWTH=1"
+        "SHELL:-sNO_DISABLE_EXCEPTION_CATCHING=1"
     )
+
+    # Generate a simple browser shell so users can run the WASM build
+    # immediately with emrun/python -m http.server without manual setup.
+    set(ALTIRRA_WASM_INDEX_TEMPLATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/cmake/wasm_index.html.in")
+    set(ALTIRRA_WASM_INDEX_OUTPUT
+        "${CMAKE_CURRENT_BINARY_DIR}/index.html")
+    configure_file("${ALTIRRA_WASM_INDEX_TEMPLATE}"
+        "${ALTIRRA_WASM_INDEX_OUTPUT}" @ONLY)
 else()
     target_link_libraries(AltirraSDL PRIVATE OpenGL::GL)
 endif()

--- a/src/AltirraSDL/cmake/wasm_index.html.in
+++ b/src/AltirraSDL/cmake/wasm_index.html.in
@@ -1,0 +1,102 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>AltirraSDL - WebAssembly</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      background: #111;
+      color: #ddd;
+      font-family: monospace;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+    h1 {
+      margin: 12px 0 8px;
+      font-size: 1rem;
+      color: #7db2ff;
+    }
+    canvas {
+      display: block;
+      width: 800px;
+      height: 600px;
+      max-width: 100vw;
+      max-height: calc(100vh - 220px);
+      background: #000;
+    }
+    #status {
+      margin: 8px;
+      font-size: 0.85rem;
+      color: #9fd89f;
+    }
+    #log {
+      width: 800px;
+      max-width: 100vw;
+      height: 140px;
+      overflow-y: auto;
+      white-space: pre;
+      background: #000;
+      border: 1px solid #333;
+      color: #aaa;
+      padding: 6px;
+      font-size: 0.75rem;
+    }
+  </style>
+</head>
+<body>
+  <h1>AltirraSDL - WebAssembly</h1>
+  <canvas id="canvas" oncontextmenu="event.preventDefault()"></canvas>
+  <div id="status">Loading...</div>
+  <div id="log"></div>
+
+  <script>
+    const statusEl = document.getElementById('status');
+    const logEl = document.getElementById('log');
+    const cacheBust = Date.now().toString();
+
+    function appendLog(text) {
+      logEl.textContent += text + '\n';
+      logEl.scrollTop = logEl.scrollHeight;
+    }
+
+    var Module = {
+      canvas: document.getElementById('canvas'),
+      print: (text) => appendLog('[stdout] ' + text),
+      printErr: (text) => appendLog('[stderr] ' + text),
+      setStatus: (text) => {
+        statusEl.textContent = text || 'Running';
+      },
+      locateFile: (path) => {
+        if (path && path.endsWith('.wasm'))
+          return path + '?v=' + cacheBust;
+        return path;
+      },
+      totalDependencies: 0,
+      monitorRunDependencies: (left) => {
+        Module.totalDependencies = Math.max(Module.totalDependencies, left);
+        if (left) {
+          Module.setStatus(
+            'Preparing... (' + (Module.totalDependencies - left) + '/' +
+            Module.totalDependencies + ')'
+          );
+        }
+      },
+      onRuntimeInitialized: () => {
+        statusEl.textContent = 'Running';
+      }
+    };
+
+    window.onerror = (msg, src, line) => {
+      appendLog('[onerror] ' + msg + ' (' + src + ':' + line + ')');
+    };
+
+    const script = document.createElement('script');
+    script.src = 'AltirraSDL.js?v=' + cacheBust;
+    document.body.appendChild(script);
+  </script>
+</body>
+</html>

--- a/src/AltirraSDL/source/app/commandline_sdl3.cpp
+++ b/src/AltirraSDL/source/app/commandline_sdl3.cpp
@@ -1044,12 +1044,37 @@ bool ATProcessCommandLineSDL3(int argc, char **argv) {
 				haveUnloadedAllImages = true;
 			}
 
+			// Smoke boot media may not include optional debugger sidecar files
+			// (e.g. .lst/.lab/.atdbg). Temporarily disable auto-load to avoid
+			// startup aborts when those files are absent in the WASM VFS.
+			IATDebugger *dbg = ATGetDebugger();
+			ATDebuggerSymbolLoadMode preStartSymMode = ATDebuggerSymbolLoadMode::Default;
+			ATDebuggerSymbolLoadMode postStartSymMode = ATDebuggerSymbolLoadMode::Default;
+			ATDebuggerScriptAutoLoadMode scriptMode = ATDebuggerScriptAutoLoadMode::Default;
+			const bool restoreDebugModes = (dbg != nullptr);
+
+			if (restoreDebugModes) {
+				preStartSymMode = dbg->GetSymbolLoadMode(false);
+				postStartSymMode = dbg->GetSymbolLoadMode(true);
+				scriptMode = dbg->GetScriptAutoLoadMode();
+
+				dbg->SetSymbolLoadMode(false, ATDebuggerSymbolLoadMode::Disabled);
+				dbg->SetSymbolLoadMode(true, ATDebuggerSymbolLoadMode::Disabled);
+				dbg->SetScriptAutoLoadMode(ATDebuggerScriptAutoLoadMode::Disabled);
+			}
+
 			const bool suppressColdReset = DoLoadDirect(
 				ALTIRRA_WASM_SMOKE_BOOT_PATH,
 				bootImageWriteMode,
 				imageCartMapper,
 				kATImageType_Program,
 				-1);
+
+			if (restoreDebugModes) {
+				dbg->SetSymbolLoadMode(false, preStartSymMode);
+				dbg->SetSymbolLoadMode(true, postStartSymMode);
+				dbg->SetScriptAutoLoadMode(scriptMode);
+			}
 
 			if (!suppressColdReset)
 				coldResetPending = true;

--- a/src/AltirraSDL/source/app/commandline_sdl3.cpp
+++ b/src/AltirraSDL/source/app/commandline_sdl3.cpp
@@ -243,9 +243,6 @@ const char *ConsumeArg(int argc, char **argv, int &i,
 // ---------------------------------------------------------------------------
 
 bool ATProcessCommandLineSDL3(int argc, char **argv) {
-	if (argc <= 1)
-		return false;
-
 	// State variables matching Windows ATUICommandLineProcessor
 	bool coldResetPending = false;
 	bool debugModeSuspend = false;
@@ -1033,6 +1030,35 @@ bool ATProcessCommandLineSDL3(int argc, char **argv) {
 			consumed[j] = true;
 		i = joinEnd;
 	}
+
+	// WebAssembly smoke mode: with no explicit startup media, auto-boot a
+	// pre-bundled image from the virtual filesystem to validate startup.
+#if defined(ALTIRRA_WASM_SMOKE_BOOT_PATH)
+	if (!hadBootImage && argc <= 1) {
+		const VDStringW smokePathW = VDTextU8ToW(VDStringSpanA(ALTIRRA_WASM_SMOKE_BOOT_PATH));
+		if (!VDDoesPathExist(smokePathW.c_str())) {
+			LOG_WARN("CmdLine", "WASM smoke media not found in VFS: %s", ALTIRRA_WASM_SMOKE_BOOT_PATH);
+		} else {
+			if (!haveUnloadedAllImages) {
+				g_sim.UnloadAll(ATUIGetBootUnloadStorageMask());
+				haveUnloadedAllImages = true;
+			}
+
+			const bool suppressColdReset = DoLoadDirect(
+				ALTIRRA_WASM_SMOKE_BOOT_PATH,
+				bootImageWriteMode,
+				imageCartMapper,
+				kATImageType_Program,
+				-1);
+
+			if (!suppressColdReset)
+				coldResetPending = true;
+
+			hadBootImage = true;
+			LOG_INFO("CmdLine", "WASM smoke auto-boot: %s", ALTIRRA_WASM_SMOKE_BOOT_PATH);
+		}
+	}
+#endif
 
 	// -----------------------------------------------------------------------
 	// Post-processing (matches Windows PostSequenceCleanup at line 782-867)

--- a/src/AltirraSDL/source/app/main_sdl3.cpp
+++ b/src/AltirraSDL/source/app/main_sdl3.cpp
@@ -32,9 +32,11 @@
 #if ALTIRRA_HAS_BAKED_ICON
 #include "altirra_icon_data.h"
 #endif
+#ifndef ALTIRRA_WASM
 #include "display_backend_gl33.h"
-#include "display_backend_sdl.h"
 #include "gl_funcs.h"
+#endif
+#include "display_backend_sdl.h"
 #include "input_sdl3.h"
 #include "touch_controls.h"
 #include "ui_mobile.h"
@@ -48,16 +50,13 @@
 #include "ui_testmode.h"
 #ifdef ALTIRRA_BRIDGE_ENABLED
 #include "bridge_server.h"
-
-#ifdef ALTIRRA_NETPLAY_ENABLED
+#endif
 #include "netplay/netplay_glue.h"
 #include "ui/netplay/ui_netplay.h"
 #include "ui/emotes/emote_picker.h"
 #include "ui/emotes/emote_assets.h"
 #include "ui/emotes/emote_netplay.h"
 #include "ui/emotes/emote_overlay.h"
-#endif
-#endif
 #include "ui_textselection.h"
 #include "ui_progress.h"
 #include "ui_emuerror.h"
@@ -1305,6 +1304,9 @@ int main(int argc, char *argv[]) {
 
 	bool useGL = false;
 	SDL_GLContext glContext = nullptr;
+#ifndef ALTIRRA_WASM
+	// On WASM, SDL_Renderer (WebGL2 via SDL3) is the only rendering path.
+	// Direct OpenGL context creation is skipped entirely.
 	GLProfile glProfile = GLProfile::Desktop33;
 
 	// Pick the preferred GL profile per platform.  Only ONE profile is
@@ -1357,6 +1359,11 @@ int main(int argc, char *argv[]) {
 		if (!g_pWindow) { LOG_INFO("Main", "CreateWindow: %s", SDL_GetError()); SDL_Quit(); return 1; }
 		LOG_INFO("Main", "Falling back to SDL_Renderer (screen FX and librashader unavailable)");
 	}
+#else // ALTIRRA_WASM
+	// WASM: skip OpenGL context creation entirely; use SDL_Renderer (WebGL2).
+	g_pWindow = SDL_CreateWindow("AltirraSDL", kDefaultWidth, kDefaultHeight, SDL_WINDOW_RESIZABLE);
+	if (!g_pWindow) { LOG_INFO("Main", "CreateWindow: %s", SDL_GetError()); SDL_Quit(); return 1; }
+#endif // ALTIRRA_WASM
 
 	// Set the window/taskbar/dock icon from the baked RGBA data.
 	// The largest image is the primary surface; smaller sizes are
@@ -1429,6 +1436,7 @@ int main(int argc, char *argv[]) {
 #endif
 
 	// Create the display backend
+#ifndef ALTIRRA_WASM
 	if (useGL) {
 		g_pBackend = new DisplayBackendGL(g_pWindow, glContext);
 		// VSync swap interval is managed dynamically by the main loop based
@@ -1443,6 +1451,13 @@ int main(int argc, char *argv[]) {
 		SDL_SetRenderVSync(g_pRenderer, 0);
 		g_pBackend = new DisplayBackendSDLRenderer(g_pWindow, g_pRenderer);
 	}
+#else // ALTIRRA_WASM
+	// WASM always uses SDL_Renderer (WebGL2 via SDL3).
+	g_pRenderer = SDL_CreateRenderer(g_pWindow, nullptr);
+	if (!g_pRenderer) { LOG_INFO("Main", "CreateRenderer: %s", SDL_GetError()); SDL_DestroyWindow(g_pWindow); SDL_Quit(); return 1; }
+	SDL_SetRenderVSync(g_pRenderer, 0);
+	g_pBackend = new DisplayBackendSDLRenderer(g_pWindow, g_pRenderer);
+#endif // ALTIRRA_WASM
 
 	// Load UI mode preference before ImGui init so ATUIApplyModeStyle()
 	// inside ATUIInit() sees the correct mode.
@@ -1510,9 +1525,11 @@ int main(int argc, char *argv[]) {
 		if (pxW <= 0) pxW = kDefaultWidth;
 		if (pxH <= 0) pxH = kDefaultHeight;
 		const char *backendName = "SDL_Renderer";
+#ifndef ALTIRRA_WASM
 		if (useGL)
 			backendName = (glProfile == GLProfile::ES30)
 				? "OpenGL ES 3.0" : "OpenGL 3.3 Core";
+#endif
 		SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
 			"Altirra: display backend = %s, window pixel size = %dx%d",
 			backendName, pxW, pxH);
@@ -1522,8 +1539,10 @@ int main(int argc, char *argv[]) {
 	// Tell the display whether the GL backend supports screen effects.
 	// This makes GTIA's IsScreenFXPreferred() return true, which enables
 	// accelerated screen effects (scanlines, bloom, color correction, etc.)
+#ifndef ALTIRRA_WASM
 	if (useGL)
 		g_pDisplay->SetScreenFXPreferred(true);
+#endif
 
 	// Auto-load last librashader preset if one was saved
 	ATUIShaderPresetsAutoLoad(g_pBackend);

--- a/src/AltirraSDL/source/display/gl_helpers.h
+++ b/src/AltirraSDL/source/display/gl_helpers.h
@@ -2,8 +2,33 @@
 
 #pragma once
 
-#include "gl_funcs.h"
-#include <vector>
+#ifdef ALTIRRA_WASM
+// -----------------------------------------------------------------------
+// WASM stubs: the GL display backend is not compiled for WebAssembly.
+// All GL helper entry points and GL constants/functions used by UI code
+// are provided as inline no-ops so callers link without change.
+// -----------------------------------------------------------------------
+#include <stdint.h>
+typedef unsigned int GLuint;
+typedef unsigned int GLenum;
+
+// GL constants used by UI files that include gl_helpers.h
+#define GL_TEXTURE_2D 0x0DE1u
+#define GL_RGBA       0x1908u
+#define GL_RGBA8      0x8058u
+#define GL_UNSIGNED_BYTE 0x1401u
+
+// Raw GL function stubs
+inline void glDeleteTextures(int, const GLuint*) {}
+inline void glBindTexture(GLenum, GLuint) {}
+
+// gl_helpers.h public API stubs
+inline GLuint GLCreateTexture2D(int, int, GLenum, GLenum, GLenum,
+	const void *, bool = true) { return 0; }
+inline GLuint GLCreateXRGB8888Texture(int, int, bool, const void *) { return 0; }
+inline void   GLUploadXRGB8888(int, int, const void *, int = 0) {}
+
+#else  // !ALTIRRA_WASM
 
 // ---------------------------------------------------------------------------
 // Shader preamble helpers
@@ -101,3 +126,5 @@ struct GLRenderTarget {
 // Draw a fullscreen triangle using the empty VAO.
 // Assumes the VAO is already bound.
 void GLDrawFullscreenTriangle();
+
+#endif // ALTIRRA_WASM

--- a/src/AltirraSDL/source/input/input_sdl3.cpp
+++ b/src/AltirraSDL/source/input/input_sdl3.cpp
@@ -486,6 +486,10 @@ static bool ATInputSDL3_IsTracedScancode(SDL_Scancode sc) {
 	}
 }
 
+#ifndef ALTIRRA_INPUT_TRACE
+#define ALTIRRA_INPUT_TRACE 0
+#endif
+
 // Bounded event trace: log up to kTraceBudget events per traced scancode,
 // each as a single line with direction, repeat flag, delta since the previous
 // event on the same scancode, and — for UP events — whether a paired KEY_DOWN
@@ -494,6 +498,7 @@ static bool ATInputSDL3_IsTracedScancode(SDL_Scancode sc) {
 // chatter; seeing "paired=no" on every UP rules that theory out entirely.
 // Once the per-scancode budget is exhausted, nothing more is logged.
 static void ATInputSDL3_TraceKeyEvent(const SDL_KeyboardEvent& ev, bool down) {
+#if ALTIRRA_INPUT_TRACE
 	if (!ATInputSDL3_IsTracedScancode(ev.scancode))
 		return;
 
@@ -550,6 +555,10 @@ static void ATInputSDL3_TraceKeyEvent(const SDL_KeyboardEvent& ev, bool down) {
 			"[input-trace]   (budget exhausted for sc=%d; no further events logged for this key)\n",
 			(int)ev.scancode);
 	}
+#else
+	(void)ev;
+	(void)down;
+#endif
 }
 
 void ATInputSDL3_HandleKeyDown(const SDL_KeyboardEvent& ev) {
@@ -570,10 +579,8 @@ void ATInputSDL3_HandleKeyDown(const SDL_KeyboardEvent& ev) {
 			// don't send to POKEY or console switches (matches Windows).
 			bool mapped = g_inputState.mpInputManager->IsInputMapped(0, inputCode);
 
-			// One-shot diagnostic: log the first time each scancode is seen,
-			// reporting whether it is currently bound through the input map.
-			// Helps diagnose user reports of "arrow keys don't work as
-			// joystick" without polluting logs during normal play.
+			// Optional one-shot diagnostics for key-map issues.
+#if ALTIRRA_INPUT_TRACE
 			static bool s_loggedScancode[SDL_SCANCODE_COUNT] = {};
 			if (!ev.repeat && !s_loggedScancode[ev.scancode]) {
 				s_loggedScancode[ev.scancode] = true;
@@ -584,18 +591,12 @@ void ATInputSDL3_HandleKeyDown(const SDL_KeyboardEvent& ev) {
 					mapped ? "yes" : "no",
 					g_kbdOpts.mbAllowInputMapOverlap ? "yes" : "no");
 
-				// On the very first input-mapped key of the session, also dump
-				// the full set of enabled input maps and the controller(s) /
-				// trigger(s) that this scancode resolves to.  This separates
-				// "no map active" from "wrong map active" from "multiple maps
-				// fighting each other" in user bug reports.
 				static bool s_dumpedMaps = false;
 				if (!s_dumpedMaps) {
 					s_dumpedMaps = true;
 					ATInputManager *im = g_inputState.mpInputManager;
 					const uint32 mapCount = im->GetInputMapCount();
-					fprintf(stderr, "[input] active input maps (%u total):\n",
-						mapCount);
+					fprintf(stderr, "[input] active input maps (%u total):\n", mapCount);
 					for (uint32 i = 0; i < mapCount; ++i) {
 						vdrefptr<ATInputMap> imap;
 						if (!im->GetInputMapByIndex(i, ~imap))
@@ -633,6 +634,7 @@ void ATInputSDL3_HandleKeyDown(const SDL_KeyboardEvent& ev) {
 					}
 				}
 			}
+#endif
 
 			// Windows uivideodisplaywindow.cpp:2225 forwards every press to
 			// OnButtonDown, including OS auto-repeats — matched here.

--- a/src/AltirraSDL/source/netplay/netplay_glue.h
+++ b/src/AltirraSDL/source/netplay/netplay_glue.h
@@ -34,6 +34,8 @@
 
 namespace ATNetplay { enum class CoordPhase; struct NetBootConfig; }
 
+#ifdef ALTIRRA_NETPLAY_ENABLED
+
 namespace ATNetplayGlue {
 
 // Phase mirror of ATNetplay::Coordinator::Phase so the UI can consume
@@ -285,3 +287,29 @@ void HostIngestPeerHint(const char* gameId,
                         const char* candidates);
 
 } // namespace ATNetplayGlue
+
+#else // !ALTIRRA_NETPLAY_ENABLED
+
+// Inline no-op stubs so non-netplay translation units compile and link
+// without the netplay module (e.g. WASM builds).
+namespace ATNetplayGlue {
+    inline bool IsActive()                          { return false; }
+    inline bool IsLockstepping()                    { return false; }
+    inline void Poll(uint64_t)                      {}
+    inline bool CanAdvanceThisTick()                { return true; }
+    inline void OnFrameAdvanced()                   {}
+    inline void SubmitLocalInput()                  {}
+    inline void ApplyFrameInputsToSim()             {}
+    inline void Shutdown()                          {}
+    inline void DisconnectActive()                  {}
+    inline bool SendEmote(uint8_t)                  { return false; }
+    inline bool IsDesynced(int64_t* = nullptr)      { return false; }
+    inline bool IsResyncing(uint32_t* = nullptr, uint32_t* = nullptr,
+                             uint32_t* = nullptr, uint32_t* = nullptr) { return false; }
+    inline uint32_t CurrentFrame()                  { return 0; }
+    inline uint32_t CurrentInputDelay()             { return 0; }
+    inline uint64_t MsSinceLastPeerPacket(uint64_t) { return UINT64_MAX / 2; }
+    inline const char* LockstepOfferId()            { return ""; }
+} // namespace ATNetplayGlue
+
+#endif // ALTIRRA_NETPLAY_ENABLED

--- a/src/AltirraSDL/source/ui/core/ui_fonts.cpp
+++ b/src/AltirraSDL/source/ui/core/ui_fonts.cpp
@@ -12,7 +12,9 @@
 #include <stdafx.h>
 #include <SDL3/SDL.h>
 #include <imgui.h>
+#ifndef ALTIRRA_WASM
 #include <imgui_impl_opengl3.h>
+#endif
 #include <imgui_impl_sdlrenderer3.h>
 #include <vd2/system/vdtypes.h>
 #include <vd2/system/VDString.h>
@@ -444,7 +446,9 @@ void ATUIFontsRebuildIfDirty() {
 	// Tear down the current backend texture so the next NewFrame uploads
 	// a fresh one built from the new atlas.
 	if (s_usingGLBackend) {
+#ifndef ALTIRRA_WASM
 		ImGui_ImplOpenGL3_DestroyFontsTexture();
+#endif
 	} else {
 		ImGui_ImplSDLRenderer3_DestroyFontsTexture();
 	}

--- a/src/AltirraSDL/source/ui/core/ui_main.cpp
+++ b/src/AltirraSDL/source/ui/core/ui_main.cpp
@@ -9,9 +9,13 @@
 #include <imgui.h>
 #include <imgui_impl_sdl3.h>
 #include <imgui_impl_sdlrenderer3.h>
+#ifndef ALTIRRA_WASM
 #include <imgui_impl_opengl3.h>
+#endif
 #include "display_backend.h"
+#ifndef ALTIRRA_WASM
 #include "display_backend_gl33.h"
+#endif
 #include "../../input/touch_widgets.h"
 
 #include <vd2/system/vdtypes.h>
@@ -1010,6 +1014,7 @@ bool ATUIInit(SDL_Window *window, IDisplayBackend *backend) {
 
 	s_pDisplayBackend = backend;
 
+#ifndef ALTIRRA_WASM
 	if (backend->GetType() == DisplayBackendType::OpenGL) {
 		s_usingGLBackend = true;
 		auto *glBackend = static_cast<DisplayBackendGL *>(backend);
@@ -1031,6 +1036,7 @@ bool ATUIInit(SDL_Window *window, IDisplayBackend *backend) {
 			GLGetActiveProfile() == GLProfile::ES30
 				? "OpenGL ES 3.0" : "OpenGL 3.3 Core");
 	} else {
+#endif // !ALTIRRA_WASM
 		s_usingGLBackend = false;
 		SDL_Renderer *renderer = backend->GetSDLRenderer();
 		if (!ImGui_ImplSDL3_InitForSDLRenderer(window, renderer)) {
@@ -1042,7 +1048,9 @@ bool ATUIInit(SDL_Window *window, IDisplayBackend *backend) {
 			return false;
 		}
 		LOG_INFO("UI", "ImGui initialized (SDL_Renderer, docking enabled)");
+#ifndef ALTIRRA_WASM
 	}
+#endif // !ALTIRRA_WASM
 
 #ifdef ALTIRRA_NETPLAY_ENABLED
 	ATNetplayUI_Initialize(window);
@@ -1059,7 +1067,9 @@ void ATUIShutdown() {
 	ATUIShutdownPaletteSolver();
 	ATUIStopRecording();
 	if (s_usingGLBackend) {
+#ifndef ALTIRRA_WASM
 		ImGui_ImplOpenGL3_Shutdown();
+#endif
 	} else {
 		ImGui_ImplSDLRenderer3_Shutdown();
 	}
@@ -1416,7 +1426,9 @@ void ATUIRenderFrame(ATSimulator &sim, VDVideoDisplaySDL3 &display,
 	ATUIFontsRebuildIfDirty();
 
 	if (s_usingGLBackend) {
+#ifndef ALTIRRA_WASM
 		ImGui_ImplOpenGL3_NewFrame();
+#endif
 	} else {
 		ImGui_ImplSDLRenderer3_NewFrame();
 	}
@@ -1601,7 +1613,9 @@ void ATUIRenderFrame(ATSimulator &sim, VDVideoDisplaySDL3 &display,
 
 	ImGui::Render();
 	if (s_usingGLBackend) {
+#ifndef ALTIRRA_WASM
 		ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
+#endif
 	} else {
 		ImGui_ImplSDLRenderer3_RenderDrawData(ImGui::GetDrawData(), backend->GetSDLRenderer());
 	}

--- a/src/AltirraSDL/source/ui/dialogs/ui_emuerror.cpp
+++ b/src/AltirraSDL/source/ui/dialogs/ui_emuerror.cpp
@@ -22,7 +22,9 @@
 #include "debugger.h"
 
 #include <at/atcore/logging.h>
+#ifdef ALTIRRA_NETPLAY_ENABLED
 extern ATLogChannel g_ATLCNetplay;
+#endif
 
 // Debugger open/close from ui_debugger.cpp
 extern void ATUIDebuggerOpen();
@@ -209,6 +211,7 @@ void ATEmuErrorHandlerSDL3::OnDebuggerOpen(IATDebugger *, ATDebuggerOpenEvent *e
 	// where a fault on one peer freezes both sides.
 	{
 		ATCPUEmulator &cpu = mpSim->GetCPU();
+#ifdef ALTIRRA_NETPLAY_ENABLED
 		g_ATLCNetplay(
 			"emu error: PC=%04X A=%02X X=%02X Y=%02X S=%02X P=%02X "
 			"mode=%d illegal=%d stopOnBRK=%d pathBrk=%d",
@@ -222,6 +225,7 @@ void ATEmuErrorHandlerSDL3::OnDebuggerOpen(IATDebugger *, ATDebuggerOpenEvent *e
 			cpu.AreIllegalInsnsEnabled() ? 1 : 0,
 			cpu.GetStopOnBRK() ? 1 : 0,
 			cpu.IsPathBreakEnabled() ? 1 : 0);
+#endif // ALTIRRA_NETPLAY_ENABLED
 	}
 
 	switch (g_ATOptions.mErrorMode) {

--- a/src/AltirraSDL/source/ui/emotes/emote_assets.h
+++ b/src/AltirraSDL/source/ui/emotes/emote_assets.h
@@ -7,6 +7,8 @@
 #include <imgui.h>
 #include <stdint.h>
 
+#ifdef ALTIRRA_NETPLAY_ENABLED
+
 namespace ATEmotes {
 
 constexpr int kCount = 16;
@@ -27,3 +29,14 @@ bool IsReady();
 ImTextureID GetTexture(int iconId, int *outW = nullptr, int *outH = nullptr);
 
 } // namespace ATEmotes
+
+#else // !ALTIRRA_NETPLAY_ENABLED
+
+namespace ATEmotes {
+    inline void Initialize()                                    {}
+    inline void Shutdown()                                      {}
+    inline bool IsReady()                                       { return false; }
+    inline ImTextureID GetTexture(int, int* = nullptr, int* = nullptr) { return (ImTextureID)nullptr; }
+} // namespace ATEmotes
+
+#endif // ALTIRRA_NETPLAY_ENABLED

--- a/src/AltirraSDL/source/ui/emotes/emote_netplay.h
+++ b/src/AltirraSDL/source/ui/emotes/emote_netplay.h
@@ -14,6 +14,8 @@
 
 #include <stdint.h>
 
+#ifdef ALTIRRA_NETPLAY_ENABLED
+
 namespace ATEmoteNetplay {
 
 // Called from the main loop after ATEmotes::Initialize() has run.
@@ -41,3 +43,19 @@ bool GetReceiveEnabled();
 void SetReceiveEnabled(bool v);
 
 } // namespace ATEmoteNetplay
+
+#else // !ALTIRRA_NETPLAY_ENABLED
+
+namespace ATEmoteNetplay {
+    inline void Initialize()                    {}
+    inline void Shutdown()                      {}
+    inline bool Send(int)                       { return false; }
+    inline void Process(uint64_t)               {}
+    inline void OnReceivedFromPeer(uint8_t)     {}
+    inline bool GetSendEnabled()                { return false; }
+    inline void SetSendEnabled(bool)            {}
+    inline bool GetReceiveEnabled()             { return false; }
+    inline void SetReceiveEnabled(bool)         {}
+} // namespace ATEmoteNetplay
+
+#endif // ALTIRRA_NETPLAY_ENABLED

--- a/src/AltirraSDL/source/ui/emotes/emote_overlay.h
+++ b/src/AltirraSDL/source/ui/emotes/emote_overlay.h
@@ -17,6 +17,8 @@
 
 #include <stdint.h>
 
+#ifdef ALTIRRA_NETPLAY_ENABLED
+
 namespace ATEmoteOverlay {
 
 // Inbound (received from peer) — top-left, slide from left.
@@ -33,3 +35,14 @@ void Clear();
 void Render(uint64_t nowMs);
 
 } // namespace ATEmoteOverlay
+
+#else // !ALTIRRA_NETPLAY_ENABLED
+
+namespace ATEmoteOverlay {
+    inline void Show(int, uint64_t)         {}
+    inline void ShowOutbound(int, uint64_t) {}
+    inline void Clear()                     {}
+    inline void Render(uint64_t)            {}
+} // namespace ATEmoteOverlay
+
+#endif // ALTIRRA_NETPLAY_ENABLED

--- a/src/AltirraSDL/source/ui/emotes/emote_picker.h
+++ b/src/AltirraSDL/source/ui/emotes/emote_picker.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#ifdef ALTIRRA_NETPLAY_ENABLED
+
 namespace ATEmotePicker {
 
 // Toggle the picker.  No-op if netplay is not lockstepping or the
@@ -25,3 +27,14 @@ bool IsOpen();
 void Render();
 
 } // namespace ATEmotePicker
+
+#else // !ALTIRRA_NETPLAY_ENABLED
+
+namespace ATEmotePicker {
+    inline void Open()      {}
+    inline void Close()     {}
+    inline bool IsOpen()    { return false; }
+    inline void Render()    {}
+} // namespace ATEmotePicker
+
+#endif // ALTIRRA_NETPLAY_ENABLED

--- a/src/AltirraSDL/source/ui/menus/ui_menus_online.cpp
+++ b/src/AltirraSDL/source/ui/menus/ui_menus_online.cpp
@@ -15,11 +15,14 @@
 #include <imgui.h>
 
 #include "ui_menus_internal.h"
+#include "netplay/netplay_glue.h"
+#include "settings.h"
+
+#ifdef ALTIRRA_NETPLAY_ENABLED
+
 #include "ui/netplay/ui_netplay.h"
 #include "ui/netplay/ui_netplay_state.h"
 #include "ui/emotes/emote_netplay.h"
-#include "netplay/netplay_glue.h"
-#include "settings.h"
 
 void ATUIRenderOnlineMenu() {
 	bool inSession = ATNetplayGlue::IsActive();
@@ -71,3 +74,8 @@ void ATUIRenderOnlineMenu() {
 		}
 	}
 }
+#else // !ALTIRRA_NETPLAY_ENABLED
+
+void ATUIRenderOnlineMenu() {}
+
+#endif // ALTIRRA_NETPLAY_ENABLED

--- a/src/AltirraSDL/source/ui/sysconfig/ui_system.cpp
+++ b/src/AltirraSDL/source/ui/sysconfig/ui_system.cpp
@@ -234,7 +234,11 @@ void ATUIRenderSystemConfig(ATSimulator &sim, ATUIState &state) {
 	case kCat_Fonts:          RenderFontsCategory(sim); break;
 	case kCat_Display2:       RenderDisplay2Category(sim); break;
 	case kCat_SettingsCfg:    RenderSettingsCfgCategory(sim); break;
-	case kCat_OnlinePlay:     RenderOnlinePlayCategory(sim); break;
+	case kCat_OnlinePlay:
+#ifdef ALTIRRA_NETPLAY_ENABLED
+		RenderOnlinePlayCategory(sim);
+#endif
+		break;
 	}
 	ImGui::EndChild();
 

--- a/src/AltirraSDL/source/ui/sysconfig/ui_system_internal.h
+++ b/src/AltirraSDL/source/ui/sysconfig/ui_system_internal.h
@@ -43,7 +43,9 @@ void RenderDebuggerCfgCategory(ATSimulator &sim);
 void RenderUICategory(ATSimulator &sim);
 void RenderDisplay2Category(ATSimulator &sim);
 void RenderSettingsCfgCategory(ATSimulator &sim);
+#ifdef ALTIRRA_NETPLAY_ENABLED
 void RenderOnlinePlayCategory(ATSimulator &sim);
+#endif
 
 // Firmware page lives in ui_firmware_category.cpp (ui/firmware/).
 void RenderFirmwareCategory(ATSimulator &sim);

--- a/src/AltirraSDL/source/ui/sysconfig/ui_system_pages_computer.cpp
+++ b/src/AltirraSDL/source/ui/sysconfig/ui_system_pages_computer.cpp
@@ -14,9 +14,7 @@
 #include "ui_system_internal.h"
 #include "simulator.h"
 
-#ifdef ALTIRRA_NETPLAY_ENABLED
 #include "netplay/netplay_glue.h"
-#endif
 #include "constants.h"
 #include "cpu.h"
 #include "firmwaremanager.h"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,6 +27,10 @@ endif()
 # Default OFF — opt in with -DALTIRRA_BRIDGE_SERVER=ON. Skipped on Android
 # because the lean target is meant for desktop / CI / container use.
 option(ALTIRRA_BRIDGE_SERVER "Build the lean headless AltirraBridgeServer" OFF)
+if(ALTIRRA_WASM AND ALTIRRA_BRIDGE_SERVER)
+    message(WARNING "ALTIRRA_BRIDGE_SERVER is not supported for ALTIRRA_WASM; forcing OFF.")
+    set(ALTIRRA_BRIDGE_SERVER OFF CACHE BOOL "Build the lean headless AltirraBridgeServer" FORCE)
+endif()
 if(ALTIRRA_BRIDGE_SERVER AND ALTIRRA_SDL3 AND NOT ANDROID)
     add_subdirectory(AltirraBridgeServer)
 endif()

--- a/src/h/at/atcore/fft.h
+++ b/src/h/at/atcore/fft.h
@@ -35,9 +35,11 @@
 #if defined(VD_CPU_X86) || defined(VD_CPU_X64)
 #define ATFFT_USE_SSE2
 #define ATFFT_USE_RADIX_4
-#else
+#elif defined(VD_CPU_ARM64) && !defined(__EMSCRIPTEN__)
+// ARM64 uses NEON intrinsics; exclude on Emscripten (WebAssembly has no NEON).
 #define ATFFT_USE_NEON
 #define ATFFT_USE_RADIX_4
+// else: scalar fallback (e.g. WASM)
 #endif
 
 enum class ATFFTTableType : uint8 {

--- a/src/h/vd2/system/cpuaccel.h
+++ b/src/h/vd2/system/cpuaccel.h
@@ -68,6 +68,11 @@ void VDCPUCleanupExtensions();
 
 #if VD_CPU_X86 || VD_CPU_X64
 extern "C" bool MMX_enabled, ISSE_enabled, SSE2_enabled;
+#elif !defined(VD_CPU_ARM64)
+// Non-x86/non-ARM64 targets (e.g. WebAssembly) have no x86 SIMD extensions.
+static constexpr bool MMX_enabled = false;
+static constexpr bool ISSE_enabled = false;
+static constexpr bool SSE2_enabled = false;
 #endif
 
 #endif

--- a/src/h/vd2/system/math.h
+++ b/src/h/vd2/system/math.h
@@ -128,7 +128,7 @@ inline sint32 VDRoundToIntFast(float x) {
 #elif defined(VD_CPU_ARM64)
 	return (int)vcvtns_s32_f32(x);
 #else
-	return (int)std::lrintf(x);
+	return (int)::lrintf(x);
 #endif
 }
 
@@ -138,7 +138,7 @@ inline sint32 VDRoundToIntFastFullRange(double x) {
 #elif defined(VD_CPU_ARM64)
 	return (int)vcvtnd_s64_f64(x);
 #else
-	return (int)std::lrint(x);
+	return (int)::lrint(x);
 #endif
 }
 

--- a/src/system/source/cpuaccel.cpp
+++ b/src/system/source/cpuaccel.cpp
@@ -50,7 +50,9 @@
 long g_lCPUExtensionsEnabled;
 
 extern "C" {
+#if VD_CPU_X86 || VD_CPU_X64
 	bool FPU_enabled, MMX_enabled, ISSE_enabled, SSE2_enabled;
+#endif
 };
 
 #if VD_CPU_X86 || VD_CPU_X64

--- a/src/system/source/zip.cpp
+++ b/src/system/source/zip.cpp
@@ -2195,7 +2195,11 @@ VDNOINLINE void VDInflateStream<T_Enhanced>::InflateBlock() {
 						copyOffset += 16;
 					} while(copyOffset < 0);
 #else
-#error Unaligned access not implemented
+					do {
+						memcpy(&copyDstEnd[copyOffset], &copySrcEnd[copyOffset], 16);
+
+						copyOffset += 16;
+					} while(copyOffset < 0);
 #endif
 				} else if (dist == 1) {
 					// Repeating with dist 1 -- memset


### PR DESCRIPTION
I mostly wanted to see if it is doable.

It is doable, but required some not-very-pretty and questionable guards and changes, so please feel free to reject this experiment.

My goal is to enable Atari 8-bit archive pages to add a "run" icon by the game so users could play the game immediately.

I was not able to incorporate OpenGL/WebGL, rendering is via SDL3 only. OpenGL in Emscripten is a bit different beast.

There is no provision for loading images, etc.

If you think this could be useful for the project, I'll be happy to work on it more.