### PR TITLE
Adjust Colors: keep "Reset to Defaults" always visible; fix UI test labels

### DIFF
--- a/src/AltirraSDL/source/ui/dialogs/ui_display.cpp
+++ b/src/AltirraSDL/source/ui/dialogs/ui_display.cpp
@@ -463,6 +463,14 @@ void ATUIRenderAdjustColors(ATSimulator &sim, ATUIState &state) {
 		ImGui::EndMenuBar();
 	}
 
+	// Scrollable body: reserve space at the bottom for a pinned footer
+	// (separator + "Reset to Defaults") so the reset button stays visible
+	// regardless of how tall the color controls get, matching Windows where
+	// Reset is always on screen.
+	const float footerHeight = ImGui::GetFrameHeightWithSpacing()
+		+ ImGui::GetStyle().ItemSpacing.y;
+	ImGui::BeginChild("##AdjustColorsBody", ImVec2(0, -footerHeight), false);
+
 	// ---- Palette preview ----
 	if (ImGui::CollapsingHeader("Palette Preview", ImGuiTreeNodeFlags_DefaultOpen)) {
 		DrawPalettePreview(gtia);
@@ -687,6 +695,9 @@ void ATUIRenderAdjustColors(ATSimulator &sim, ATUIState &state) {
 		gtia.SetColorSettings(settings);
 	}
 
+	ImGui::EndChild();
+
+	// Pinned footer (outside the scrolling body) — always visible.
 	ImGui::Separator();
 
 	if (ImGui::Button("Reset to Defaults")) {

--- a/tests/ui/test_dialogs.py
+++ b/tests/ui/test_dialogs.py
@@ -58,14 +58,18 @@ class TestAdjustColors:
 
     WIN = "Adjust Colors"
 
+    # Labels match Windows Altirra's Adjust Colors dialog: the hue-range
+    # slider is shown as "Hue Step" (per-step angle) and gamma as
+    # "Gamma Correction".
     EXPECTED_SLIDERS = [
-        "Hue Start", "Hue Range",
-        "Brightness", "Contrast", "Saturation", "Gamma", "Intensity Scale",
+        "Hue Start", "Hue Step",
+        "Brightness", "Contrast", "Saturation", "Gamma Correction", "Intensity Scale",
     ]
 
+    # PAL quirks is an Options-menu item (enabled only in PAL mode), not a
+    # body checkbox, so it is not asserted here.
     EXPECTED_CHECKBOXES = [
         "Share NTSC/PAL settings",
-        "PAL quirks",
     ]
 
     def test_widgets_exist(self, emu: AltirraTestHarness):

--- a/tests/ui/test_integration.py
+++ b/tests/ui/test_integration.py
@@ -188,8 +188,8 @@ class TestColorAdjustments:
         emu.open_dialog("AdjustColors")
         emu.wait_frames(5)
         labels = emu.get_item_labels("Adjust Colors")
-        for slider in ["Hue Start", "Hue Range", "Brightness", "Contrast",
-                        "Saturation", "Gamma", "Intensity Scale"]:
+        for slider in ["Hue Start", "Hue Step", "Brightness", "Contrast",
+                        "Saturation", "Gamma Correction", "Intensity Scale"]:
             assert slider in labels, f"Slider '{slider}' missing from Adjust Colors"
 
     def test_reset_to_defaults(self, emu: AltirraTestHarness):


### PR DESCRIPTION
Keeps the **Reset to Defaults** button always reachable in the Adjust Colors dialog, and aligns the UI tests with the dialog's actual labels.

## Problem
The Adjust Colors dialog can grow taller than the window (palette preview + many sliders). When it does, the bottom separator and the **Reset to Defaults** button scroll off-screen, so there's no way to reset — unlike the Windows Altirra dialog where Reset is always visible.

## Fix
- Wrap the color controls in a scrolling child region (`BeginChild`/`EndChild`).
- Pin the footer (separator + **Reset to Defaults**) **outside** the scrolling region so it stays on screen regardless of content height.

## Test alignment
The UI tests expected stale labels; updated them to match what the dialog actually renders (consistent with Windows naming):
- `Hue Range` → `Hue Step`
- `Gamma` → `Gamma Correction`
- Dropped `PAL quirks` from the expected body checkboxes — it is a PAL-only **Options menu** item, not a body control.

## Files
- `src/AltirraSDL/source/ui/dialogs/ui_display.cpp`
- `tests/ui/test_dialogs.py`
- `tests/ui/test_integration.py`
