### PR TITLE
Fix bridge audio state and WASM canvas sync

### DIFF
--- a/.github/workflows/bridge-package.yml
+++ b/.github/workflows/bridge-package.yml
@@ -197,6 +197,12 @@ jobs:
                       assert png[:8] == b'\x89PNG\r\n\x1a\n'
                       insns = a.disasm(0xe477, 4)
                       assert 'COLDSV' in insns[0]['text']
+                      a.pause()
+                      for i in range(14):
+                          a.joy(0, 'down' if i % 2 == 0 else 'centre')
+                      a.key('A')
+                      assert a.eval_expr('db($d209)') == 0x3f
+                      assert (a.eval_expr('db($d20f)') & 0x04) == 0
                   print(f"python sdk OK (attempt {attempt+1})")
                   break
               except (BridgeError, ConnectionError, OSError) as e:

--- a/src/AltirraSDL/AltirraBridge/docs/PROTOCOL.md
+++ b/src/AltirraSDL/AltirraBridge/docs/PROTOCOL.md
@@ -1013,7 +1013,11 @@ shadow plus the collision read-side.
 
 Decoded POKEY per-channel audio state, including AUDCTL flag
 decoding (16-bit channel pairs, fast 1.79 MHz clock per channel,
-high-pass routes, base clock).
+high-pass routes, base clock). Each channel also reports the effective
+POKEY timer period in machine cycles and the timer-derived waveform
+frequency in Hz. `freq_hz` is `null` when the channel has no waveform
+output; in 16-bit joined modes, the combined frequency is reported on
+channel 2 or 4.
 
 ```json
 {"ok":true,"audctl":"$28",
@@ -1021,7 +1025,8 @@ high-pass routes, base clock).
  "highpass_1_3":false,"highpass_2_4":false,"base_15khz":false,
  "channels":[
    {"channel":1,"audf":"$00","audc":"$00","volume":0,
-    "volume_only":false,"distortion":0,"clock":"64kHz"},
+    "volume_only":false,"distortion":0,"clock":"64kHz",
+    "period_cycles":28,"freq_hz":null},
    ...
  ]}
 ```

--- a/src/AltirraSDL/AltirraBridge/sdk/python/altirra_bridge/client.py
+++ b/src/AltirraSDL/AltirraBridge/sdk/python/altirra_bridge/client.py
@@ -938,7 +938,9 @@ class AltirraBridge:
         """Decoded POKEY per-channel state: ``audctl``, flags
         (``nine_bit_poly``, ``join_1_2``, etc.), and a ``channels``
         list of 4 dicts with ``audf``, ``audc``, ``volume``,
-        ``distortion``, ``clock`` (``"64kHz"``/``"15kHz"``/``"1.79MHz"``).
+        ``distortion``, ``clock`` (``"64kHz"``/``"15kHz"``/``"1.79MHz"``),
+        ``period_cycles``, and ``freq_hz``. ``freq_hz`` is ``None``
+        when the channel has no waveform output.
         """
         return self._cmd_ok("AUDIO_STATE")
 

--- a/src/AltirraSDL/cmake/wasm_index.html.in
+++ b/src/AltirraSDL/cmake/wasm_index.html.in
@@ -2420,17 +2420,31 @@
       return { w, h };
     }
 
+    let lastSdlCanvasSyncW = 0;
+    let lastSdlCanvasSyncH = 0;
+
     function syncCanvasSizeToCssBox(force) {
       const size = getCanvasCssSize();
       if (size.w <= 0 || size.h <= 0) return false;
 
-      if (!force && canvas.width === size.w && canvas.height === size.h)
+      const canSyncSdl = (typeof Module !== 'undefined'
+          && Module._ATWasmSyncCanvasSize);
+
+      if (!force
+          && canvas.width === size.w && canvas.height === size.h
+          && (!canSyncSdl
+              || (lastSdlCanvasSyncW === size.w
+                  && lastSdlCanvasSyncH === size.h)))
         return false;
 
       let syncedBySdl = false;
-      if (typeof Module !== 'undefined' && Module._ATWasmSyncCanvasSize) {
+      if (canSyncSdl) {
         try {
           syncedBySdl = (Module._ATWasmSyncCanvasSize(size.w, size.h) === 1);
+          if (syncedBySdl) {
+            lastSdlCanvasSyncW = size.w;
+            lastSdlCanvasSyncH = size.h;
+          }
         } catch (e) {}
       }
 

--- a/src/AltirraSDL/source/bridge/bridge_commands_debug.cpp
+++ b/src/AltirraSDL/source/bridge/bridge_commands_debug.cpp
@@ -52,12 +52,22 @@ void AddU32(std::string& out, const char* key, uint32_t value) {
 	out += '"';  out += key;  out += "\":";  out += std::to_string(value);  out += ',';
 }
 
+void AddDouble(std::string& out, const char* key, double value) {
+	char b[64];
+	std::snprintf(b, sizeof b, "%.9g", value);
+	out += '"';  out += key;  out += "\":";  out += b;  out += ',';
+}
+
 void AddStr(std::string& out, const char* key, const std::string& value) {
 	out += '"';  out += key;  out += "\":\"";  out += JsonEscape(value);  out += "\",";
 }
 
 void AddBool(std::string& out, const char* key, bool value) {
 	out += '"';  out += key;  out += "\":";  out += (value ? "true" : "false");  out += ',';
+}
+
+void AddNull(std::string& out, const char* key) {
+	out += '"';  out += key;  out += "\":null,";
 }
 
 void StripTrailingComma(std::string& s) {
@@ -90,6 +100,53 @@ void SnapshotPokeyRegs(ATPokeyEmulator& pokey, uint8_t out[32]) {
 	ATPokeyRegisterState st {};
 	pokey.GetRegisterState(st);
 	std::memcpy(out, st.mReg, 32);
+}
+
+uint32_t GetPokeyTimerPeriodCycles(const uint8_t reg[32], uint8_t audctl, int ch) {
+	const bool base15k = (audctl & 0x01) != 0;
+	const bool fast1 = (audctl & 0x40) != 0;
+	const bool fast3 = (audctl & 0x20) != 0;
+	const bool join12 = (audctl & 0x10) != 0;
+	const bool join34 = (audctl & 0x08) != 0;
+	const bool fastTimer = ch == 0 ? fast1 : ch == 2 ? fast3 : false;
+	const bool hiLinkedTimer = ch == 1 ? join12 : ch == 3 ? join34 : false;
+	const bool loLinkedTimer = ch == 0 ? join12 : ch == 2 ? join34 : false;
+
+	if (hiLinkedTimer) {
+		const int loCh = ch & ~1;
+		const bool fastLinkedTimer = ch == 1 ? fast1 : fast3;
+		uint32_t period = ((uint32_t)reg[0x00 + ch * 2] << 8)
+			+ (uint32_t)reg[0x00 + loCh * 2] + 1;
+
+		if (fastLinkedTimer)
+			period += 6;
+		else if (base15k)
+			period *= 114;
+		else
+			period *= 28;
+
+		return period;
+	}
+
+	if (loLinkedTimer) {
+		if (fastTimer)
+			return 256;
+		else if (base15k)
+			return 256 * 114;
+		else
+			return 256 * 28;
+	}
+
+	uint32_t period = (uint32_t)reg[0x00 + ch * 2] + 1;
+
+	if (fastTimer)
+		period += 3;
+	else if (base15k)
+		period *= 114;
+	else
+		period *= 28;
+
+	return period;
 }
 
 }  // namespace
@@ -599,6 +656,9 @@ std::string CmdAudioState(ATSimulator& sim, const std::vector<std::string>& toke
 	const bool hp_1_3    = (audctl & 0x04) != 0;
 	const bool hp_2_4    = (audctl & 0x02) != 0;
 	const bool base_15k  = (audctl & 0x01) != 0;
+	const double schedulerRate = sim.GetScheduler()
+		? sim.GetScheduler()->GetRate().asDouble()
+		: 1789772.5;
 
 	std::string channels;
 	channels += '[';
@@ -608,6 +668,8 @@ std::string CmdAudioState(ATSimulator& sim, const std::vector<std::string>& toke
 		const uint8_t distortion = (uint8_t)((audc >> 5) & 0x07);
 		const bool    volume_only = (audc & 0x10) != 0;
 		const uint8_t volume     = (uint8_t)(audc & 0x0f);
+		const uint32_t periodCycles = GetPokeyTimerPeriodCycles(reg, audctl, ch);
+		const bool hasWaveform = !volume_only && volume != 0;
 
 		// Clock source for this channel
 		const char* clock_name = base_15k ? "15kHz" : "64kHz";
@@ -624,6 +686,11 @@ std::string CmdAudioState(ATSimulator& sim, const std::vector<std::string>& toke
 		AddBool (e, "volume_only",volume_only);
 		AddU32  (e, "distortion", distortion);
 		AddStr  (e, "clock",      clock_name);
+		AddU32  (e, "period_cycles", periodCycles);
+		if (hasWaveform && periodCycles)
+			AddDouble(e, "freq_hz", schedulerRate / (2.0 * (double)periodCycles));
+		else
+			AddNull(e, "freq_hz");
 		StripTrailingComma(e);
 		channels += e;
 		channels += '}';


### PR DESCRIPTION
## Summary
- add `period_cycles` and `freq_hz` to `AUDIO_STATE`, including fast clock and 16-bit joined POKEY timer handling
- keep the WASM canvas/C-side SDL size sync from being skipped after fullscreen/orientation changes when the browser already resized the backing store
- add a bridge smoke regression for the reported JOY burst followed by KEY injection path

## Issue context
- Addresses #71
- Likely fix for #67 based on the stale WASM canvas-size sync path
- Adds regression coverage for #72, which I could not reproduce on current `main`
- I inspected #46, but did not find a safe root-cause fix from code alone

## Verification
- `cmake --build build/issue-debug --target AltirraBridgeServer -j$(nproc)`
- `git diff --check`
- live bridge checks for `AUDIO_STATE` default, 64 kHz tone, 1.79 MHz fast clock, and joined 1+2 mode
