### PR TITLE
testmode: automation verbs (mem_read, controller input, speed control) + non-interactive quit

### DIFF
--- a/src/AltirraSDL/source/app/main_sdl3.cpp
+++ b/src/AltirraSDL/source/app/main_sdl3.cpp
@@ -518,7 +518,13 @@ static void HandleEvents() {
 		switch (ev.type) {
 		case SDL_EVENT_QUIT:
 		case SDL_EVENT_WINDOW_CLOSE_REQUESTED:
-			if (g_uiState.exitConfirmed)
+			// Test-mode runs are non-interactive: a SIGTERM/SIGINT or a
+			// programmatic SDL_EVENT_QUIT (e.g. from the test-mode `quit`
+			// command) means "exit now".  Skip the Confirm Exit modal —
+			// there is no human to dismiss it, and leaving the dialog up
+			// would wedge the process and also pollute any screenshot
+			// the test driver takes around shutdown time.
+			if (g_uiState.exitConfirmed || g_testModeEnabled)
 				g_running = false;
 			else if (!g_uiState.showExitConfirm)
 				g_uiState.showExitConfirm = true;  // Render loop will open the popup

--- a/src/AltirraSDL/source/ui/testmode/ui_testmode.cpp
+++ b/src/AltirraSDL/source/ui/testmode/ui_testmode.cpp
@@ -715,6 +715,48 @@ static std::string DispatchCommand(std::string cmd, ATSimulator &sim, ATUIState 
 		);
 	}
 
+	// --- Speed control ---
+	//
+	// Format:  set_speed <turbo|warp|normal|real>
+	//          get_speed
+	//
+	// `turbo` / `warp` enable the sticky turbo mode (== Tab key in
+	// the GUI) so the simulator runs as fast as the host CPU allows.
+	// `normal` / `real` clear it so the simulator runs at its native
+	// ~60 Hz NTSC (or 50 Hz PAL) rate.
+	//
+	// Test-mode defaults to whatever the user's settings.ini specified
+	// (typically normal speed); use this verb at the start of a
+	// capture session if you need to override.
+	//
+	// Interaction with wait_frames: wait_frames counts RENDERED frames
+	// (decremented in ATTestModePostRender), and the turbo frame-skip
+	// renders only 1 of every engine.turbo_fps_divisor (default 16)
+	// emulated frames — so `wait_frames N` under turbo spans roughly
+	// N*divisor emulated frames.  Scripts that count emulated frames
+	// should stay at normal speed or divide accordingly.
+	if (verb == "set_speed") {
+		std::string mode = NextToken(cmd);
+		if (mode.empty())
+			return JsonError("usage: set_speed <turbo|warp|normal|real>");
+		if (mode == "turbo" || mode == "warp") {
+			ATUISetTurbo(true);
+			return JsonOk();
+		}
+		if (mode == "normal" || mode == "real") {
+			ATUISetTurbo(false);
+			return JsonOk();
+		}
+		return JsonError("unknown speed mode: " + mode);
+	}
+
+	if (verb == "get_speed") {
+		std::string body = "{\"ok\":true,\"turbo\":";
+		body += ATUIGetTurbo() ? "true" : "false";
+		body += "}";
+		return body;
+	}
+
 	// --- Emulation control ---
 	if (verb == "cold_reset") {
 		sim.ColdReset();
@@ -809,6 +851,8 @@ static std::string DispatchCommand(std::string cmd, ATSimulator &sim, ATUIState 
 			"\"mem_read <hex_addr> [<count>]\","
 			"\"input joy <unit> <left|right|up|down|fire|release_all>\","
 			"\"input console <start|select|option> [up]\","
+			"\"set_speed <turbo|warp|normal|real>\","
+			"\"get_speed\","
 			"\"cold_reset\","
 			"\"warm_reset\","
 			"\"pause\","

--- a/src/AltirraSDL/source/ui/testmode/ui_testmode.cpp
+++ b/src/AltirraSDL/source/ui/testmode/ui_testmode.cpp
@@ -25,6 +25,9 @@
 #include "simulator.h"
 #include "gtia.h"
 #include "oshelper.h"
+#include "inputmanager.h"
+#include "inputdefs.h"
+#include "netplay/netplay_input.h"
 #include "logging.h"
 
 bool g_testModeEnabled = false;
@@ -617,6 +620,101 @@ static std::string DispatchCommand(std::string cmd, ATSimulator &sim, ATUIState 
 		return body;
 	}
 
+	// --- Controller input ---
+	//
+	// Format:  input joy <unit> <action>
+	//          input console <button> [up]
+	//
+	// joy actions:   left | right | up | down | fire | release_all
+	// console btns:  start | select | option
+	//                ("up" suffix releases the switch; default = press)
+	//
+	// <unit> is the input-map controller unit (0 = first/default
+	// controller); which console port it drives is decided by the
+	// active input map, exactly as for a physical game controller.
+	//
+	// Joystick state is sticky — a press is held until release_all.
+	// Directions on one axis are exclusive: pressing left releases
+	// right and vice versa (same for up/down), because a physical
+	// stick cannot hold both and ATInputManager does no such
+	// exclusion itself.  The caller (test script) owns press/release
+	// scheduling so frame timing stays deterministic.
+	if (verb == "input") {
+		std::string sub = NextToken(cmd);
+
+		if (sub == "joy") {
+			std::string unitStr = NextToken(cmd);
+			std::string action  = NextToken(cmd);
+			if (unitStr.empty() || action.empty())
+				return JsonError("usage: input joy <unit> <action>");
+			int unit = atoi(unitStr.c_str());
+			if (unit < 0 || unit > 3)
+				return JsonError("unit must be 0..3");
+			ATInputManager *im = sim.GetInputManager();
+			if (!im)
+				return JsonError("no input manager");
+
+			if (action == "release_all") {
+				im->OnButtonUp(unit, kATInputCode_JoyStick1Left);
+				im->OnButtonUp(unit, kATInputCode_JoyStick1Right);
+				im->OnButtonUp(unit, kATInputCode_JoyStick1Up);
+				im->OnButtonUp(unit, kATInputCode_JoyStick1Down);
+				im->OnButtonUp(unit, kATInputCode_JoyButton0);
+				return JsonOk();
+			}
+
+			int code = -1;
+			int opposite = -1;
+			if (action == "left") {
+				code = kATInputCode_JoyStick1Left;
+				opposite = kATInputCode_JoyStick1Right;
+			} else if (action == "right") {
+				code = kATInputCode_JoyStick1Right;
+				opposite = kATInputCode_JoyStick1Left;
+			} else if (action == "up") {
+				code = kATInputCode_JoyStick1Up;
+				opposite = kATInputCode_JoyStick1Down;
+			} else if (action == "down") {
+				code = kATInputCode_JoyStick1Down;
+				opposite = kATInputCode_JoyStick1Up;
+			} else if (action == "fire") {
+				code = kATInputCode_JoyButton0;
+			} else
+				return JsonError("unknown joy action: " + action);
+
+			// Enforce per-axis exclusivity (see header comment): a
+			// physical stick cannot hold left+right or up+down, and
+			// some games misbehave on the impossible state.
+			if (opposite >= 0)
+				im->OnButtonUp(unit, opposite);
+			im->OnButtonDown(unit, code);
+			return JsonOk();
+		}
+
+		if (sub == "console") {
+			std::string button = NextToken(cmd);
+			std::string state  = NextToken(cmd);   // optional "up"
+			if (button.empty())
+				return JsonError("usage: input console <start|select|option> [up]");
+
+			uint8 bit = 0;
+			if      (button == "start")  bit = 0x01;
+			else if (button == "select") bit = 0x02;
+			else if (button == "option") bit = 0x04;
+			else
+				return JsonError("unknown console button: " + button);
+
+			ATGTIAEmulator &gtia = sim.GetGTIA();
+			ATNetplayInput::RouteConsoleSwitch(&gtia, bit, state != "up");
+			return JsonOk();
+		}
+
+		return JsonError(
+			"usage: input joy <unit> <left|right|up|down|fire|release_all>"
+			" | input console <start|select|option> [up]"
+		);
+	}
+
 	// --- Emulation control ---
 	if (verb == "cold_reset") {
 		sim.ColdReset();
@@ -709,6 +807,8 @@ static std::string DispatchCommand(std::string cmd, ATSimulator &sim, ATUIState 
 			"\"wait_frames [n]\","
 			"\"screenshot <path>\","
 			"\"mem_read <hex_addr> [<count>]\","
+			"\"input joy <unit> <left|right|up|down|fire|release_all>\","
+			"\"input console <start|select|option> [up]\","
 			"\"cold_reset\","
 			"\"warm_reset\","
 			"\"pause\","

--- a/src/AltirraSDL/source/ui/testmode/ui_testmode.cpp
+++ b/src/AltirraSDL/source/ui/testmode/ui_testmode.cpp
@@ -572,6 +572,51 @@ static std::string DispatchCommand(std::string cmd, ATSimulator &sim, ATUIState 
 		return "{\"ok\":true,\"path\":\"" + JsonEscape(path) + "\"}";
 	}
 
+	// --- Memory inspection (read-only, side-effect-free) ---
+	// Reads bytes via ATSimulator::DebugReadByte so I/O reads do not
+	// trigger side effects (collision-clear, IRQ ack, etc).  Useful for
+	// dynamic analysis of disassembled software: dump zero-page,
+	// inspect object arrays, verify hypotheses about register usage.
+	//
+	// Format:  mem_read <hex_addr> [<count>]
+	// Default count = 1.  Max count = 4096 (one response packet).
+	// Response: {"ok":true,"addr":"$xxxx","bytes":[h0,h1,...]}
+	if (verb == "mem_read") {
+		std::string addrStr  = NextToken(cmd);
+		std::string countStr = NextToken(cmd);
+		if (addrStr.empty())
+			return JsonError("usage: mem_read <hex_addr> [<count>]");
+
+		// Reject unparseable input loudly.  A debugging verb that
+		// silently falls back to reading $0000 on a typo would hand the
+		// caller wrong-but-plausible data — worse than any error.
+		char *end = nullptr;
+		uint32 addr = (uint32)strtoul(addrStr.c_str(), &end, 16);
+		if (end == addrStr.c_str() || *end)
+			return JsonError("bad hex address: " + addrStr);
+
+		uint32 count = 1;
+		if (!countStr.empty()) {
+			count = (uint32)strtoul(countStr.c_str(), &end, 0);
+			if (end == countStr.c_str() || *end)
+				return JsonError("bad count: " + countStr);
+		}
+		if (count == 0) count = 1;
+		if (count > 4096) count = 4096;
+		std::string body = "{\"ok\":true,\"addr\":\"$";
+		char buf[32];
+		snprintf(buf, sizeof(buf), "%04X", addr & 0xFFFF);
+		body += buf;
+		body += "\",\"bytes\":[";
+		for (uint32 i = 0; i < count; ++i) {
+			uint8 b = sim.DebugReadByte((uint16)((addr + i) & 0xFFFF));
+			snprintf(buf, sizeof(buf), "%s%u", i ? "," : "", (unsigned)b);
+			body += buf;
+		}
+		body += "]}";
+		return body;
+	}
+
 	// --- Emulation control ---
 	if (verb == "cold_reset") {
 		sim.ColdReset();
@@ -663,6 +708,7 @@ static std::string DispatchCommand(std::string cmd, ATSimulator &sim, ATUIState 
 			"\"mouse_move <x> <y>\","
 			"\"wait_frames [n]\","
 			"\"screenshot <path>\","
+			"\"mem_read <hex_addr> [<count>]\","
 			"\"cold_reset\","
 			"\"warm_reset\","
 			"\"pause\","

--- a/tests/ui/harness.py
+++ b/tests/ui/harness.py
@@ -210,6 +210,24 @@ class AltirraTestHarness:
     def save_state(self, path: str) -> dict:
         return self.send(f"save_state {path}")
 
+    def mem_read(self, addr: int, count: int = 1) -> list[int]:
+        """Side-effect-free RAM/register read; returns the byte list."""
+        resp = self.send(f"mem_read {addr:04X} {count}")
+        return resp["bytes"]
+
+    def input_joy(self, unit: int, action: str) -> dict:
+        return self.send(f"input joy {unit} {action}")
+
+    def input_console(self, button: str, up: bool = False) -> dict:
+        return self.send(f"input console {button}{' up' if up else ''}")
+
+    def set_speed(self, mode: str) -> dict:
+        return self.send(f"set_speed {mode}")
+
+    def get_speed(self) -> bool:
+        """Return True if sticky turbo mode is engaged."""
+        return self.send("get_speed")["turbo"]
+
     # ── Convenience helpers ──────────────────────────────────────────────
 
     def get_dialog_state(self, name: str) -> bool:

--- a/tests/ui/test_automation_verbs.py
+++ b/tests/ui/test_automation_verbs.py
@@ -1,0 +1,249 @@
+"""
+Automation verbs: mem_read, input joy/console, set_speed/get_speed,
+and the non-interactive quit path.
+
+These verbs exist for scripted sessions (dynamic analysis, gameplay
+harnesses, capture pipelines).  The joystick/console tests assert
+against the emulated hardware registers via mem_read, so they verify
+the full chain: socket verb -> input manager / GTIA -> PIA/GTIA
+register state the running program would actually see.
+
+Hardware registers used (all read side-effect-free via DebugReadByte):
+  PORTA  $D300  joystick port 1 in low nibble, active low
+                (bit0 up, bit1 down, bit2 left, bit3 right)
+  TRIG0  $D010  joystick 1 trigger, 0 = pressed
+  CONSOL $D01F  console switches, active low
+                (bit0 Start, bit1 Select, bit2 Option)
+"""
+
+import signal
+import subprocess
+import time
+
+import pytest
+from .harness import AltirraTestHarness, CommandError
+
+PORTA = 0xD300
+TRIG0 = 0xD010
+CONSOL = 0xD01F
+
+PORTA_IDLE = 0xFF
+PORTA_LEFT = 0xFF & ~0x04
+PORTA_RIGHT = 0xFF & ~0x08
+PORTA_UP = 0xFF & ~0x01
+PORTA_DOWN = 0xFF & ~0x02
+
+CONSOL_IDLE = 0x07
+
+
+def wait_reg(emu: AltirraTestHarness, addr: int, expected: int,
+             tries: int = 30) -> int:
+    """Poll a register until it reads `expected` (or give up).
+
+    Input edges propagate to PIA/GTIA state within a frame or two, but
+    not synchronously with the socket reply (e.g. console switches can
+    be deferred a frame by the netplay input glue) — so assertions poll
+    instead of assuming a fixed frame delay.  Returns the last value
+    read, so `assert wait_reg(...) == expected` reports it on failure.
+    """
+    val = emu.mem_read(addr, 1)[0]
+    for _ in range(tries):
+        if val == expected:
+            break
+        emu.wait_frames(2)
+        val = emu.mem_read(addr, 1)[0]
+    return val
+
+
+@pytest.fixture(scope="session")
+def booted(emu: AltirraTestHarness):
+    """Wait until the OS has finished booting.
+
+    Until OS init sets PACTL bit 2, $D300 reads back the PIA *direction*
+    register (0 after reset), not the port — so joystick state is only
+    observable once boot has settled and PORTA reads idle ($FF).
+    """
+    emu.input_joy(0, "release_all")
+    deadline = time.monotonic() + 15
+    while time.monotonic() < deadline:
+        if emu.mem_read(PORTA, 1)[0] == PORTA_IDLE:
+            return
+        emu.wait_frames(10)
+    pytest.fail("PORTA never reached idle state — OS boot did not settle")
+
+
+@pytest.fixture(autouse=True)
+def _release_inputs(emu: AltirraTestHarness):
+    """Leave no stuck input or speed override behind for later tests."""
+    yield
+    try:
+        emu.input_joy(0, "release_all")
+        emu.set_speed("normal")
+        emu.wait_frames(2)
+    except Exception:
+        pass  # best-effort cleanup
+
+
+class TestMemRead:
+    """mem_read returns ground-truth bytes and rejects bad input loudly."""
+
+    def test_single_byte_default_count(self, emu: AltirraTestHarness):
+        resp = emu.send("mem_read D300")
+        assert resp["ok"] is True
+        assert resp["addr"] == "$D300"
+        assert len(resp["bytes"]) == 1
+
+    def test_count_and_values_are_bytes(self, emu: AltirraTestHarness):
+        data = emu.mem_read(0x0600, 16)
+        assert len(data) == 16
+        assert all(0 <= b <= 255 for b in data)
+
+    def test_count_clamped_to_4096(self, emu: AltirraTestHarness):
+        resp = emu.send("mem_read 0000 99999")
+        assert len(resp["bytes"]) == 4096
+
+    def test_address_wraps_16bit(self, emu: AltirraTestHarness):
+        # Reading 4 bytes at $FFFF wraps to $0000 without error
+        resp = emu.send("mem_read FFFF 4")
+        assert len(resp["bytes"]) == 4
+
+    def test_bad_address_is_an_error(self, emu: AltirraTestHarness):
+        with pytest.raises(CommandError, match="bad hex address"):
+            emu.send("mem_read zzz")
+
+    def test_bad_count_is_an_error(self, emu: AltirraTestHarness):
+        with pytest.raises(CommandError, match="bad count"):
+            emu.send("mem_read 0600 bogus")
+
+    def test_missing_address_is_usage_error(self, emu: AltirraTestHarness):
+        with pytest.raises(CommandError, match="usage"):
+            emu.send("mem_read")
+
+
+@pytest.mark.usefixtures("booted")
+class TestJoystickInput:
+    """input joy drives PIA/GTIA state exactly as a physical stick could."""
+
+    def test_idle_state(self, emu: AltirraTestHarness):
+        emu.input_joy(0, "release_all")
+        assert wait_reg(emu, PORTA, PORTA_IDLE) == PORTA_IDLE
+        assert wait_reg(emu, TRIG0, 1) == 1
+
+    @pytest.mark.parametrize("action,expected", [
+        ("left", PORTA_LEFT),
+        ("right", PORTA_RIGHT),
+        ("up", PORTA_UP),
+        ("down", PORTA_DOWN),
+    ])
+    def test_direction_press(self, emu: AltirraTestHarness, action, expected):
+        emu.input_joy(0, "release_all")
+        emu.input_joy(0, action)
+        assert wait_reg(emu, PORTA, expected) == expected, \
+            f"{action} should pull its PORTA bit low"
+
+    def test_opposite_directions_are_exclusive(self, emu: AltirraTestHarness):
+        # A physical stick cannot hold left+right: pressing right must
+        # release left (and vice versa), not combine into an impossible
+        # state some games glitch on.
+        emu.input_joy(0, "release_all")
+        emu.input_joy(0, "left")
+        assert wait_reg(emu, PORTA, PORTA_LEFT) == PORTA_LEFT
+        emu.input_joy(0, "right")
+        assert wait_reg(emu, PORTA, PORTA_RIGHT) == PORTA_RIGHT, \
+            "pressing right must release left, not hold both"
+
+    def test_diagonal_is_allowed(self, emu: AltirraTestHarness):
+        # Distinct axes combine fine — diagonals are real stick states.
+        emu.input_joy(0, "release_all")
+        emu.input_joy(0, "up")
+        emu.input_joy(0, "left")
+        expected = PORTA_UP & PORTA_LEFT
+        assert wait_reg(emu, PORTA, expected) == expected
+
+    def test_fire_and_release_all(self, emu: AltirraTestHarness):
+        emu.input_joy(0, "fire")
+        emu.input_joy(0, "down")
+        assert wait_reg(emu, TRIG0, 0) == 0, "TRIG0 reads 0 while fire is held"
+        emu.input_joy(0, "release_all")
+        assert wait_reg(emu, TRIG0, 1) == 1
+        assert wait_reg(emu, PORTA, PORTA_IDLE) == PORTA_IDLE
+
+    def test_bad_unit_is_an_error(self, emu: AltirraTestHarness):
+        with pytest.raises(CommandError, match="unit must be 0..3"):
+            emu.input_joy(7, "left")
+
+    def test_bad_action_is_an_error(self, emu: AltirraTestHarness):
+        with pytest.raises(CommandError, match="unknown joy action"):
+            emu.input_joy(0, "wiggle")
+
+
+@pytest.mark.usefixtures("booted")
+class TestConsoleSwitches:
+    """input console drives GTIA CONSOL state (active low)."""
+
+    @pytest.mark.parametrize("button,bit", [
+        ("start", 0x01),
+        ("select", 0x02),
+        ("option", 0x04),
+    ])
+    def test_press_release(self, emu: AltirraTestHarness, button, bit):
+        emu.input_console(button)
+        assert wait_reg(emu, CONSOL, CONSOL_IDLE & ~bit) == (CONSOL_IDLE & ~bit), \
+            f"{button} should pull CONSOL bit {bit:#04x} low"
+        emu.input_console(button, up=True)
+        assert wait_reg(emu, CONSOL, CONSOL_IDLE) == CONSOL_IDLE
+
+    def test_bad_button_is_an_error(self, emu: AltirraTestHarness):
+        with pytest.raises(CommandError, match="unknown console button"):
+            emu.input_console("reset")
+
+
+class TestSpeedControl:
+    """set_speed/get_speed toggle sticky turbo, consistent with query_state."""
+
+    def test_default_is_realtime(self, emu: AltirraTestHarness):
+        emu.set_speed("normal")
+        assert emu.get_speed() is False
+
+    @pytest.mark.parametrize("on,off", [("turbo", "normal"), ("warp", "real")])
+    def test_aliases_round_trip(self, emu: AltirraTestHarness, on, off):
+        emu.set_speed(on)
+        assert emu.get_speed() is True
+        emu.set_speed(off)
+        assert emu.get_speed() is False
+
+    def test_matches_query_state(self, emu: AltirraTestHarness):
+        emu.set_speed("turbo")
+        assert emu.get_sim_state()["turbo"] is True
+        emu.set_speed("normal")
+        assert emu.get_sim_state()["turbo"] is False
+
+    def test_bad_mode_is_an_error(self, emu: AltirraTestHarness):
+        with pytest.raises(CommandError, match="unknown speed mode"):
+            emu.set_speed("ludicrous")
+
+
+class TestNonInteractiveQuit:
+    """Test-mode close events must not hang on the Confirm Exit modal.
+
+    Uses a private emulator instance — these tests end the process.
+    """
+
+    def test_quit_verb_exits(self):
+        with AltirraTestHarness() as solo:
+            solo.ping()
+            solo.send_raw("quit")
+            assert solo._proc.wait(timeout=10) == 0
+
+    def test_sigterm_exits_cleanly(self):
+        # Pre-fix, SIGTERM raised the Confirm Exit modal and the process
+        # hung until killed; in test mode there is no human to dismiss it.
+        with AltirraTestHarness() as solo:
+            solo.ping()
+            solo._proc.send_signal(signal.SIGTERM)
+            try:
+                code = solo._proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                pytest.fail("process still running 10s after SIGTERM "
+                            "(Confirm Exit modal bypass not working)")
+            assert code == 0


### PR DESCRIPTION
## What

Four small additions to the `--test-mode` socket protocol, aimed at scripted/automated sessions (dynamic analysis, gameplay harnesses, capture pipelines), plus pytest coverage for all of them in `tests/ui/`. All verbs are listed in `help` output and return the existing `{"ok":false,"error":"..."}` shape on bad arguments.

### 1. Non-interactive close in test mode

`SDL_EVENT_QUIT` / `SDL_EVENT_WINDOW_CLOSE_REQUESTED` bypass the Confirm Exit modal when `--test-mode` is active. A test-mode run is non-interactive: there is no human to dismiss the dialog, so a `kill -TERM` (or programmatic quit) would previously wedge the process with the modal up — and pollute any screenshot taken around shutdown. With this change `kill -TERM` exits cleanly with settings saved.

(Intentionally applies to *any* close event while in test mode — that seemed like the right semantics for an automation mode, but happy to gate it differently if you prefer.)

### 2. `mem_read <hex_addr> [<count>]`

Side-effect-free RAM reads via `ATSimulator::DebugReadByte()` (no collision-clear, IRQ ack, or other I/O side effects that ordinary CPU reads would trigger). Max 4096 bytes per call. Gives external tools a ground-truth feedback channel beyond screenshots — e.g. verifying zero-page state hypotheses while analysing software under emulation. Unparseable address/count is rejected loudly rather than silently falling back to `$0000`.

```
mem_read 0600 4   →   {"ok":true,"addr":"$0600","bytes":[0,0,0,0]}
```

### 3. `input joy <unit> <left|right|up|down|fire|release_all>` / `input console <start|select|option> [up]`

Scripted controller input over the socket. Joystick flows through `ATInputManager::OnButtonDown/Up` with the same `kATInputCode_JoyStick1*` codes `input_sdl3.cpp` and `touch_controls.cpp` use; console switches go through `ATNetplayInput::RouteConsoleSwitch` (same pattern as touch_controls) so netplay sessions see the edge.

Joystick state is sticky until `release_all`, with per-axis exclusivity enforced: pressing a direction releases its opposite first, since a physical stick cannot hold left+right or up+down (and `ATInputManager` does no such exclusion itself — some games misbehave on the impossible state).

### 4. `set_speed <turbo|warp|normal|real>` / `get_speed`

Exposes `ATUISetTurbo()` (== Tab in the GUI) so capture sessions can fast-forward. One interaction documented in the code: `wait_frames` counts *rendered* frames, and the turbo frame-skip renders only 1 of every `engine.turbo_fps_divisor` (default 16) emulated frames — so `wait_frames N` under turbo spans ~N×divisor emulated frames.

## Tests

`tests/ui/test_automation_verbs.py` (28 tests) plus harness wrappers. The joystick/console tests assert against emulated hardware state via `mem_read` — PORTA `$D300`, TRIG0 `$D010`, CONSOL `$D01F` — so they verify the full chain: socket verb → input manager / GTIA → the register values a running program would actually see. Includes a regression test that left+right cannot be co-held, and `quit`/SIGTERM clean-exit tests using a private emulator instance.

Two environment subtleties the tests encode (useful for future test authors): `$D300` reads back the PIA *direction* register (0) until OS boot sets PACTL bit 2, so register tests gate on boot having settled; and input edges aren't synchronous with the socket reply (the netplay input glue can defer a console edge by a frame), so assertions poll briefly instead of assuming a fixed frame delay.

Full `tests/ui` suite: 161 passed (133 pre-existing + 28 new), stable across repeated runs. Linux release build clean.