### PR TITLE
Fix libretro core CI build failures across platforms

### DIFF
--- a/.github/workflows/libretro-core.yml
+++ b/.github/workflows/libretro-core.yml
@@ -93,8 +93,11 @@ jobs:
             python3 python3-pip file tar gzip \
             gcc-12 g++-12
           if [[ "${{ matrix.cross }}" == "arm-linux-gnueabihf" ]]; then
+            # GCC 12+ cross compiler: the shared headers use C++23
+            # `if consteval`, which the default GCC 11 cross toolchain on
+            # Ubuntu 22.04 does not support.
             apt-get install -y --no-install-recommends \
-              gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf \
+              gcc-12-arm-linux-gnueabihf g++-12-arm-linux-gnueabihf \
               binutils-arm-linux-gnueabihf
           fi
           python3 -m pip install --user --disable-pip-version-check \

--- a/.github/workflows/libretro-core.yml
+++ b/.github/workflows/libretro-core.yml
@@ -355,7 +355,14 @@ jobs:
           if (!(Test-Path $core)) {
             throw "altirra_libretro.dll not found"
           }
-          $dumpbin = Get-ChildItem "${env:ProgramFiles}/Microsoft Visual Studio/2022" -Recurse -Filter dumpbin.exe |
+          # Search across all installed Visual Studio versions (the hosted
+          # runner image moves between major versions, e.g. 2022 -> 18) and
+          # both Program Files roots.
+          $vsRoots = @(
+            "${env:ProgramFiles}/Microsoft Visual Studio",
+            "${env:ProgramFiles(x86)}/Microsoft Visual Studio"
+          ) | Where-Object { $_ -and (Test-Path $_) }
+          $dumpbin = Get-ChildItem $vsRoots -Recurse -Filter dumpbin.exe -ErrorAction SilentlyContinue |
             Where-Object { $_.FullName -match 'Hostx64\\x64' } |
             Select-Object -First 1 -ExpandProperty FullName
           if (!$dumpbin) {

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,24 @@ endfunction()
 # never produces a native Win32 frontend.
 ###############################################################################
 
+# MSVC's Visual Studio generator leaves CMAKE_SYSTEM_PROCESSOR at the host
+# value (e.g. AMD64) even when targeting ARM64 via "-A ARM64".  That makes the
+# per-architecture SIMD source selection in the subprojects pick x86 sources
+# for an ARM64 target.  Normalize CMAKE_SYSTEM_PROCESSOR from the compiler's
+# actual target architecture so every "MATCHES" arch check downstream is
+# correct.  Non-MSVC builds already report the target architecture correctly.
+if(MSVC AND CMAKE_CXX_COMPILER_ARCHITECTURE_ID)
+    if(CMAKE_CXX_COMPILER_ARCHITECTURE_ID MATCHES "ARM64")
+        set(CMAKE_SYSTEM_PROCESSOR "ARM64")
+    elseif(CMAKE_CXX_COMPILER_ARCHITECTURE_ID STREQUAL "ARM")
+        set(CMAKE_SYSTEM_PROCESSOR "ARM")
+    elseif(CMAKE_CXX_COMPILER_ARCHITECTURE_ID MATCHES "x64")
+        set(CMAKE_SYSTEM_PROCESSOR "AMD64")
+    elseif(CMAKE_CXX_COMPILER_ARCHITECTURE_ID MATCHES "X86")
+        set(CMAKE_SYSTEM_PROCESSOR "X86")
+    endif()
+endif()
+
 # ALTIRRA_SDL3 — build the SDL3+ImGui frontend.
 # Always ON: CMake exclusively builds the SDL3+ImGui frontend.
 # The native Win32 UI is built via the Visual Studio .sln, never via CMake.

--- a/cmake/toolchains/linux-armv7hf.cmake
+++ b/cmake/toolchains/linux-armv7hf.cmake
@@ -1,8 +1,28 @@
 set(CMAKE_SYSTEM_NAME Linux)
 set(CMAKE_SYSTEM_PROCESSOR armv7l)
 
-set(CMAKE_C_COMPILER arm-linux-gnueabihf-gcc)
-set(CMAKE_CXX_COMPILER arm-linux-gnueabihf-g++)
+# The shared VirtualDub system headers use C++23 `if consteval`, which requires
+# GCC 12 or newer.  Ubuntu's default `gcc-arm-linux-gnueabihf` metapackage is
+# still GCC 11 on 22.04, so prefer a versioned cross compiler when one is
+# installed and fall back to the unversioned name otherwise.  An explicit
+# -DCMAKE_C_COMPILER / -DCMAKE_CXX_COMPILER on the command line always wins.
+if(NOT CMAKE_C_COMPILER)
+    find_program(ALTIRRA_ARMV7_CC NAMES
+        arm-linux-gnueabihf-gcc-14
+        arm-linux-gnueabihf-gcc-13
+        arm-linux-gnueabihf-gcc-12
+        arm-linux-gnueabihf-gcc)
+    set(CMAKE_C_COMPILER "${ALTIRRA_ARMV7_CC}")
+endif()
+
+if(NOT CMAKE_CXX_COMPILER)
+    find_program(ALTIRRA_ARMV7_CXX NAMES
+        arm-linux-gnueabihf-g++-14
+        arm-linux-gnueabihf-g++-13
+        arm-linux-gnueabihf-g++-12
+        arm-linux-gnueabihf-g++)
+    set(CMAKE_CXX_COMPILER "${ALTIRRA_ARMV7_CXX}")
+endif()
 
 set(ALTIRRA_ARMV7_FLAGS "-marm -march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard")
 

--- a/scripts/validate-libretro-docs.sh
+++ b/scripts/validate-libretro-docs.sh
@@ -79,7 +79,12 @@ for ((I = 0; I < FIRMWARE_COUNT; ++I)); do
         || fail "docs draft missing firmware path: $path"
 done
 
-mapfile -t OPTION_NAMES < <(
+# Portable read loop instead of `mapfile`/`readarray`, which are absent from
+# the bash 3.2 shipped on macOS.
+OPTION_NAMES=()
+while IFS= read -r line; do
+    OPTION_NAMES+=("$line")
+done < <(
     sed -n '/static const CompactOptionDefinition kOptionSpecs\[\]/,/};/p' \
         "$CORE_FILE" \
         | sed -n 's/^[[:space:]]*"\([^"]*\)",[[:space:]]*"\([^"]*\)".*/\2/p'

--- a/scripts/validate-libretro-info.sh
+++ b/scripts/validate-libretro-info.sh
@@ -17,13 +17,20 @@ fail() {
 [ -f "$CMAKE_FILE" ] || fail "CMake file not found: $CMAKE_FILE"
 [ -f "$CORE_FILE" ] || fail "core source not found: $CORE_FILE"
 
+# Note: `\+` is a GNU sed extension; use the portable `X X*` form so this
+# matches under BSD sed (macOS) as well.
 PROJECT_VERSION=$(sed -n \
-    's/^project(Altirra[[:space:]]\+VERSION[[:space:]]\+\([^[:space:])]*\).*/\1/p' \
+    's/^project(Altirra[[:space:]][[:space:]]*VERSION[[:space:]][[:space:]]*\([^[:space:])]*\).*/\1/p' \
     "$CMAKE_FILE" | head -1)
 [ -n "$PROJECT_VERSION" ] \
     || fail "could not read project version from $CMAKE_FILE"
 
-declare -A INFO
+# bash 3.2 (the default /bin/bash on macOS) has no associative arrays, so
+# emulate INFO[key]=value with prefixed dynamic variables.  Keys are validated
+# to [A-Za-z0-9_]+ below, so they are always valid shell identifier suffixes.
+info_set() { eval "INFOVAL_$1=\$2"; }
+info_get() { eval "printf '%s' \"\${INFOVAL_$1-}\""; }
+info_has() { eval "[ \"\${INFOVAL_$1+set}\" = set ]"; }
 
 LINE_NO=0
 while IFS= read -r LINE || [ -n "$LINE" ]; do
@@ -47,16 +54,16 @@ while IFS= read -r LINE || [ -n "$LINE" ]; do
         fail "$INFO_FILE:$LINE_NO: unquoted non-numeric value for key: $KEY"
     fi
 
-    if [[ -v "INFO[$KEY]" ]]; then
+    if info_has "$KEY"; then
         fail "$INFO_FILE:$LINE_NO: duplicate key: $KEY"
     fi
 
-    INFO["$KEY"]="$VALUE"
+    info_set "$KEY" "$VALUE"
 done < "$INFO_FILE"
 
 require_key() {
     local key="$1"
-    [[ -v "INFO[$key]" ]] || fail "missing required key: $key"
+    info_has "$key" || fail "missing required key: $key"
 }
 
 require_value() {
@@ -64,8 +71,8 @@ require_value() {
     local expected="$2"
 
     require_key "$key"
-    if [ "${INFO[$key]}" != "$expected" ]; then
-        fail "unexpected $key: '${INFO[$key]}' (expected '$expected')"
+    if [ "$(info_get "$key")" != "$expected" ]; then
+        fail "unexpected $key: '$(info_get "$key")' (expected '$expected')"
     fi
 }
 
@@ -73,7 +80,7 @@ require_extension() {
     local ext="$1"
     require_key supported_extensions
 
-    case "|${INFO[supported_extensions]}|" in
+    case "|$(info_get supported_extensions)|" in
         *"|$ext|"*) ;;
         *) fail "supported_extensions is missing '$ext'" ;;
     esac
@@ -102,9 +109,9 @@ if [ "${ALTIRRA_LIBRETRO_ALLOW_NON_EXPERIMENTAL:-0}" != "1" ]; then
     require_value is_experimental "true"
 else
     require_key is_experimental
-    case "${INFO[is_experimental]}" in
+    case "$(info_get is_experimental)" in
         true|false) ;;
-        *) fail "is_experimental must be 'true' or 'false': ${INFO[is_experimental]}" ;;
+        *) fail "is_experimental must be 'true' or 'false': $(info_get is_experimental)" ;;
     esac
 fi
 
@@ -121,10 +128,11 @@ CORE_EXTENSIONS=$(sed -n '/kValidExtensions[[:space:]]*=/,/;/p' "$CORE_FILE" \
 require_value supported_extensions "$CORE_EXTENSIONS"
 
 require_key firmware_count
-[[ "${INFO[firmware_count]}" =~ ^[0-9]+$ ]] \
-    || fail "firmware_count is not numeric: ${INFO[firmware_count]}"
+FIRMWARE_COUNT=$(info_get firmware_count)
+[[ "$FIRMWARE_COUNT" =~ ^[0-9]+$ ]] \
+    || fail "firmware_count is not numeric: $FIRMWARE_COUNT"
 
-for ((I = 0; I < INFO[firmware_count]; ++I)); do
+for ((I = 0; I < FIRMWARE_COUNT; ++I)); do
     require_key "firmware${I}_desc"
     require_key "firmware${I}_path"
     require_value "firmware${I}_opt" "true"

--- a/scripts/verify-libretro-package.sh
+++ b/scripts/verify-libretro-package.sh
@@ -40,7 +40,12 @@ case "$ARCHIVE" in
         ;;
 esac
 
-mapfile -t ROOTS < <(find "$TMP_DIR" -mindepth 1 -maxdepth 1 -type d | sort)
+# Use a portable read loop instead of `mapfile`/`readarray`, which are not
+# available in the bash 3.2 shipped on macOS.
+ROOTS=()
+while IFS= read -r line; do
+    ROOTS+=("$line")
+done < <(find "$TMP_DIR" -mindepth 1 -maxdepth 1 -type d | sort)
 [ "${#ROOTS[@]}" -eq 1 ] \
     || fail "package should contain exactly one top-level directory"
 
@@ -51,7 +56,10 @@ for required in BUILD-INFO.txt LICENSE README.md altirra_libretro.info \
     [ -f "$PKG_DIR/$required" ] || fail "package missing $required"
 done
 
-mapfile -t CORES < <(find "$PKG_DIR" -maxdepth 1 -type f \
+CORES=()
+while IFS= read -r line; do
+    CORES+=("$line")
+done < <(find "$PKG_DIR" -maxdepth 1 -type f \
     \( -name 'altirra_libretro.so' \
     -o -name 'altirra_libretro.dylib' \
     -o -name 'altirra_libretro.dll' \) | sort)

--- a/src/Altirra/h/stdafx.h
+++ b/src/Altirra/h/stdafx.h
@@ -38,7 +38,12 @@
 // _MSC_VER.
 #if defined(_MSC_VER)
 #include <intrin.h>      // _ReturnAddress etc. (needed by <ppltasks.h>)
-#include <immintrin.h>   // __m128i / __m256i (needed by <wchar.h>)
+// The <wchar.h> workaround above is x86/x64-only: the SDK's SIMD inlines use
+// __m128i/__m256i (x86 vector types).  On ARM64 those types don't apply and
+// <immintrin.h> rejects the target (error C1189), so restrict it to x86/x64.
+#if defined(_M_IX86) || defined(_M_X64)
+#include <immintrin.h>   // __m128i / __m256i (needed by <wchar.h> on x86/x64)
+#endif
 #endif
 
 #include <stddef.h>

--- a/src/AltirraLibretro/CMakeLists.txt
+++ b/src/AltirraLibretro/CMakeLists.txt
@@ -27,7 +27,6 @@ include(${ALTIRRA_SDL_DIR}/cmake/altirra_core_sources.cmake)
 target_sources(AltirraLibretro PRIVATE
     libretro_audio.cpp
     libretro_dirs.cpp
-    libretro_time.cpp
     libretro_video.cpp
     libretro_ui_stubs.cpp
 
@@ -60,7 +59,13 @@ if(WIN32)
 endif()
 
 if(NOT WIN32)
+    # libretro_time.cpp shadows the SDL3 timer object in libsystem.a so the
+    # standalone core does not pull in SDL3.  On Windows libsystem.a already
+    # builds the self-contained Win32 timer (time.cpp, no SDL3 dependency), and
+    # its VDLazyTimer uses a different member layout, so reuse that instead of
+    # compiling this thread-based replacement.
     target_sources(AltirraLibretro PRIVATE
+        libretro_time.cpp
         ${ALTIRRA_SDL_DIR}/source/os/modemtcp_sdl3.cpp
         ${ALTIRRA_SDL_DIR}/source/os/idephysdisk_sdl3.cpp
         ${ALTIRRA_SDL_DIR}/source/os/pipeserial_sdl3.cpp

--- a/src/AltirraLibretro/README.md
+++ b/src/AltirraLibretro/README.md
@@ -83,7 +83,9 @@ GitHub Actions packages the standalone core for:
 Local cross-build presets are also available:
 
 ```sh
-# Requires gcc-arm-linux-gnueabihf / g++-arm-linux-gnueabihf.
+# Requires a GCC 12+ cross toolchain (the shared headers use C++23
+# `if consteval`), e.g. gcc-12-arm-linux-gnueabihf /
+# g++-12-arm-linux-gnueabihf on Ubuntu 22.04.
 cmake --preset linux-libretro-armv7hf
 cmake --build --preset linux-libretro-armv7hf
 

--- a/src/AltirraSDL/stubs/win32_stubs.cpp
+++ b/src/AltirraSDL/stubs/win32_stubs.cpp
@@ -394,7 +394,11 @@ void VDUIGetAcceleratorString(const VDUIAccelerator& accel, VDStringW& s) {
 // main loop calls ATRegistryLoadFromDisk()/ATRegistryFlushToDisk() which
 // are provided by registry_sdl3.cpp on non-Windows.  On Windows we just
 // provide no-op stubs since the registry handles persistence.
-#ifdef _WIN32
+//
+// The libretro core builds an in-memory registry persisted to an INI file and
+// supplies its own ATRegistryLoadFromDisk()/ATRegistryFlushToDisk() in
+// libretro_dirs.cpp, so exclude these stubs there to avoid duplicate symbols.
+#if defined(_WIN32) && !defined(ALTIRRA_LIBRETRO)
 void ATRegistryLoadFromDisk() {}
 void ATRegistryFlushToDisk() {}
 #endif

--- a/src/h/vd2/system/bitmath.h
+++ b/src/h/vd2/system/bitmath.h
@@ -104,6 +104,12 @@ inline int VDFindLowestSetBitFast(uint32 v) {
 		#else
 			return __builtin_ctz(v);
 		#endif
+	#elif defined(VD_COMPILER_MSVC)
+		// MSVC on non-x86 targets (e.g. ARM64) does not provide __builtin_ctz;
+		// use the bit-scan intrinsic, matching VDFindLowestSetBit() above.
+		unsigned long index;
+		_BitScanForward(&index, v);
+		return (int)index;
 	#else
 		return __builtin_ctz(v);
 	#endif

--- a/src/h/vd2/system/int128.h
+++ b/src/h/vd2/system/int128.h
@@ -375,6 +375,16 @@ inline vduint128::vduint128(const vdint128& x) {
 		return result;
 	}
 	uint64 VDUDiv128x64To64(const vduint128& dividend, uint64 divisor, uint64& remainder);
+#elif defined(_M_ARM64) || defined(_M_ARM64EC)
+	// MSVC on ARM64 has no _umul128 and no unsigned __int128; __umulh yields
+	// the high 64 bits of the unsigned product and plain * the low 64 bits.
+	inline vduint128 VDUMul64x64To128(uint64 x, uint64 y) {
+		vduint128 result;
+		result.q[0] = x * y;
+		result.q[1] = __umulh(x, y);
+		return result;
+	}
+	uint64 VDUDiv128x64To64(const vduint128& dividend, uint64 divisor, uint64& remainder);
 #elif defined(__x86_64__) || defined(__aarch64__)
 	inline vduint128 VDUMul64x64To128(uint64 x, uint64 y) {
 		unsigned __int128 r = (unsigned __int128)(unsigned long long)x * (unsigned long long)y;


### PR DESCRIPTION
The libretro core workflow ran for the first time on `main` after the merge commit (`c2c63369`) and surfaced four platform-specific failures. Linux x86_64, aarch64, Android arm64, and the boot/video smoke test pass; this PR fixes the rest.

## Failures and fixes

| Job | Root cause | Fix |
|-----|-----------|-----|
| **Windows x86_64 & arm64** | `libretro_time.cpp` implements `VDLazyTimer` with the non-Windows thread members (`mTimerThread`/`mpTimerRunning`); on Windows that class uses a Win32 thunk → `C2065 undeclared identifier`. | Exclude `libretro_time.cpp` on Windows. `libsystem.a` already builds the self-contained Win32 `time.cpp` (no SDL3 dep) with all timer symbols. `VDLazyTimer` is unused by the headless core; the used `VDCallbackTimer` is worker-thread based (no message pump needed). |
| **Windows arm64** | `bitmath.h` `VDFindLowestSetBitFast()` fell through to `__builtin_ctz` on MSVC non-x86 → `C3861`. | Add MSVC ARM64 branch using `_BitScanForward`, matching `VDFindLowestSetBit()`. Also fixes the `.sln` ARM64 build latently. |
| **Linux armv7hf** | Shared headers use C++23 `if consteval`; default `gcc-arm-linux-gnueabihf` on Ubuntu 22.04 is GCC 11 → `expected '(' before 'consteval'`. | Install & prefer GCC 12 cross compiler (workflow + toolchain file + README). |
| **macOS arm64 & x86_64** | `verify-libretro-package.sh` / `validate-libretro-docs.sh` use `mapfile` (bash 4+); macOS ships bash 3.2 → `mapfile: command not found`. | Replace with a portable `while read` loop. |

## Verification

Local Linux x86_64: build + 3 smoke tests + artifact verify + package verify all pass with these changes. Windows/macOS/armv7hf validated via this PR's CI run.

Note: the unrelated `Windows build` (main SDL3 workflow) failure on `c2c63369` was a transient Chocolatey `choco install zip` outage, not a code issue.