### PR TITLE
Annotate upstream-tracked fork changes with AltirraSDL markers

### DIFF
--- a/src/Altirra/h/stdafx.h
+++ b/src/Altirra/h/stdafx.h
@@ -38,9 +38,12 @@
 // _MSC_VER.
 #if defined(_MSC_VER)
 #include <intrin.h>      // _ReturnAddress etc. (needed by <ppltasks.h>)
-// The <wchar.h> workaround above is x86/x64-only: the SDK's SIMD inlines use
-// __m128i/__m256i (x86 vector types).  On ARM64 those types don't apply and
-// <immintrin.h> rejects the target (error C1189), so restrict it to x86/x64.
+// AltirraSDL: fork change for the Windows-on-ARM64 build. The <immintrin.h>
+// <wchar.h> workaround is x86/x64-only — the SDK's SIMD inlines use
+// __m128i/__m256i (x86 vector types). On ARM64 those don't apply and
+// <immintrin.h> rejects the target (error C1189), so the include is guarded to
+// x86/x64. Upstream includes it unconditionally for MSVC. Preserve this guard
+// when re-syncing from upstream.
 #if defined(_M_IX86) || defined(_M_X64)
 #include <immintrin.h>   // __m128i / __m256i (needed by <wchar.h> on x86/x64)
 #endif

--- a/src/h/vd2/system/bitmath.h
+++ b/src/h/vd2/system/bitmath.h
@@ -105,8 +105,11 @@ inline int VDFindLowestSetBitFast(uint32 v) {
 			return __builtin_ctz(v);
 		#endif
 	#elif defined(VD_COMPILER_MSVC)
-		// MSVC on non-x86 targets (e.g. ARM64) does not provide __builtin_ctz;
-		// use the bit-scan intrinsic, matching VDFindLowestSetBit() above.
+		// AltirraSDL: fork addition for the Windows-on-ARM64 build. Upstream
+		// only handles MSVC under the x86/AMD64 branch above and otherwise
+		// falls through to __builtin_ctz, which MSVC does not provide on
+		// non-x86 targets. Use _BitScanForward instead, matching
+		// VDFindLowestSetBit() above. Preserve when re-syncing from upstream.
 		unsigned long index;
 		_BitScanForward(&index, v);
 		return (int)index;

--- a/src/h/vd2/system/int128.h
+++ b/src/h/vd2/system/int128.h
@@ -376,8 +376,12 @@ inline vduint128::vduint128(const vdint128& x) {
 	}
 	uint64 VDUDiv128x64To64(const vduint128& dividend, uint64 divisor, uint64& remainder);
 #elif defined(_M_ARM64) || defined(_M_ARM64EC)
-	// MSVC on ARM64 has no _umul128 and no unsigned __int128; __umulh yields
-	// the high 64 bits of the unsigned product and plain * the low 64 bits.
+	// AltirraSDL: fork addition for the Windows-on-ARM64 build. Upstream
+	// inlines VDUMul64x64To128 only for MSVC x64 (_umul128) and GCC/Clang
+	// (unsigned __int128); MSVC on ARM64 has neither and would fall through to
+	// the out-of-line declaration below, which int128.cpp does not define for
+	// ARM64. __umulh yields the high 64 bits of the unsigned product and plain
+	// '*' the low 64 bits. Preserve when re-syncing from upstream.
 	inline vduint128 VDUMul64x64To128(uint64 x, uint64 y) {
 		vduint128 result;
 		result.q[0] = x * y;


### PR DESCRIPTION
Follow-up to the libretro CI fixes. Three of those changes were in files synced
from upstream Windows Altirra / VirtualDub:

- `src/h/vd2/system/bitmath.h` — MSVC ARM64 `_BitScanForward` branch
- `src/h/vd2/system/int128.h` — MSVC ARM64 `VDUMul64x64To128` via `__umulh`
- `src/Altirra/h/stdafx.h` — `<immintrin.h>` guarded to x86/x64

This PR adds the project's `// AltirraSDL:` fork-marker convention and a
"preserve when re-syncing from upstream" note to each, so a future mainline
(test-branch) merge recognizes them as intentional deviations rather than
accidental conflicts — per `docs/merging-with-altirra-mainline.md`.

Comment-only; no behavior change. (All other libretro fixes were in fork-only
files — the CMake build, SDL3 stubs, scripts, and the AltirraLibretro target —
which upstream does not carry.)