### PR TITLE
WASM: add ?joystick= deep link + ATWasmSetJoystickStyle export

### DIFF
--- a/src/AltirraSDL/cmake/wasm_lib_deeplink.js
+++ b/src/AltirraSDL/cmake/wasm_lib_deeplink.js
@@ -88,6 +88,7 @@
     //   artifact:   0..6|null         (?artifact=none|ntsc|pal|ntschi|palhi|auto|autohi)
     //   vkbd:       true|false|null   (?vkbd=0|1)
     //   stretch:    0..4|null         (?stretch=fill|preserve|square|integral|integral_preserve)
+    //   joystick:   0..2|null         (?joystick=analog|dpad8|dpad4)
     //   ui:         'desktop'|'gaming'|null  (?ui=…)  overrides the
     //              auto-pick that forces Gaming Mode whenever ?lib= is set.
     //   manualStart:true|false        (?autoplay=0)  pause until user clicks
@@ -99,6 +100,7 @@
     artifact:    null,
     vkbd:        null,
     stretch:     null,
+    joystick:    null,
     ui:          null,
     manualStart: false,
     // First-run silent defaults — `?experience=` and `?addons=`.
@@ -527,6 +529,25 @@
               + window.__altirraLib.stretch + ')');
         } else {
           log('ignored unknown stretch value:', stretchRaw);
+        }
+      }
+
+      // ?joystick=analog|dpad8|dpad4 — touch-joystick style for this
+      // launch.  Maps to ATTouchJoystickStyle (touch_layout.h).  Lets
+      // a per-game launcher pick the right stick per title — grid
+      // games (Boulder Dash) want dpad4's cardinal snap, 8-way games
+      // (Bruce Lee) want dpad8/analog diagonals — without touching
+      // the user's saved preference.  Applied via
+      // ATWasmSetJoystickStyle once the runtime is ready.
+      var joystickMap = { analog: 0, dpad8: 1, dpad4: 2 };
+      var joystickRaw = (p.get('joystick') || '').trim().toLowerCase();
+      if (joystickRaw) {
+        if (joystickRaw in joystickMap) {
+          window.__altirraLib.joystick = joystickMap[joystickRaw];
+          log('joystick=' + joystickRaw + ' (style='
+              + window.__altirraLib.joystick + ')');
+        } else {
+          log('ignored unknown joystick value:', joystickRaw);
         }
       }
 
@@ -1102,6 +1123,9 @@
     }
     if (lib.stretch !== null && Module._ATWasmSetStretchMode) {
       try { Module._ATWasmSetStretchMode(lib.stretch); } catch (e) {}
+    }
+    if (lib.joystick !== null && Module._ATWasmSetJoystickStyle) {
+      try { Module._ATWasmSetJoystickStyle(lib.joystick); } catch (e) {}
     }
     // Manual-start (?autoplay=0) needs no work here — the host page
     // (wasm_index.html.in) handles it entirely outside the runtime

--- a/src/AltirraSDL/source/app/wasm_bridge.cpp
+++ b/src/AltirraSDL/source/app/wasm_bridge.cpp
@@ -1797,6 +1797,25 @@ void ATWasmSetTouchControls(int on) {
 	g_mobileState.showTouchControls = (on != 0);
 }
 
+// Touch-joystick style override (?joystick= deep link / embedder JS).
+// 0 = Analog, 1 = D-Pad 8, 2 = D-Pad 4 — the ATTouchJoystickStyle
+// values the mobile Settings page cycles through.  Different games
+// want different styles (grid games play best on D-Pad 4, diagonal
+// games on 8-way/analog), so a per-game launcher needs a per-launch
+// override.  The setter only touches the in-memory config: the user's
+// saved preference is untouched unless they later change a setting in
+// the mobile Settings page (which persists the whole layout config).
+extern "C" EMSCRIPTEN_KEEPALIVE
+int ATWasmGetJoystickStyle() {
+	return (int)g_mobileState.layoutConfig.joystickStyle;
+}
+extern "C" EMSCRIPTEN_KEEPALIVE
+void ATWasmSetJoystickStyle(int style) {
+	if (style < (int)ATTouchJoystickStyle::Analog || style > (int)ATTouchJoystickStyle::DPad4)
+		return;
+	g_mobileState.layoutConfig.joystickStyle = (ATTouchJoystickStyle)style;
+}
+
 // -----------------------------------------------------------------------
 // Broker mode (M3): chrome suppression + Starting overlay + session-end
 // navigation.


### PR DESCRIPTION
Implements item 3 of #81 — per-launch touch-joystick style.

- `ATWasmSetJoystickStyle(int)` / `ATWasmGetJoystickStyle()` exports mirroring `ATWasmSetTouchControls`; values are the `ATTouchJoystickStyle` enum (0 analog, 1 dpad8, 2 dpad4), out-of-range values ignored. In-memory only — the user's saved style preference is not overwritten.
- `?joystick=analog|dpad8|dpad4` in `wasm_lib_deeplink.js`, parsed and applied post-runtime exactly like the existing `?filter=`/`?stretch=`/`?vkbd=` embed-kit params.

Example: `?lib=BoulderDash.xex&joystick=dpad4`

Build-verified with emsdk 5.0.6 (wasm-release preset): links clean, both exports present in the generated loader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)