### PR TITLE
WASM: add ?consolekeys= deep link + ATWasmSetConsoleKeys export

### DIFF
--- a/src/AltirraSDL/cmake/wasm_lib_deeplink.js
+++ b/src/AltirraSDL/cmake/wasm_lib_deeplink.js
@@ -87,6 +87,7 @@
     //   filter:     0..4|null         (?filter=point|bilinear|sharp|bicubic|auto)
     //   artifact:   0..6|null         (?artifact=none|ntsc|pal|ntschi|palhi|auto|autohi)
     //   vkbd:       true|false|null   (?vkbd=0|1)
+    //   consolekeys:true|false|null   (?consolekeys=0|1)
     //   stretch:    0..4|null         (?stretch=fill|preserve|square|integral|integral_preserve)
     //   ui:         'desktop'|'gaming'|null  (?ui=…)  overrides the
     //              auto-pick that forces Gaming Mode whenever ?lib= is set.
@@ -98,6 +99,7 @@
     filter:      null,
     artifact:    null,
     vkbd:        null,
+    consolekeys: null,
     stretch:     null,
     ui:          null,
     manualStart: false,
@@ -500,6 +502,22 @@
         log('vkbd=' + (window.__altirraLib.vkbd ? '1' : '0'));
       } else if (vkbdRaw) {
         log('ignored unknown vkbd value:', vkbdRaw);
+      }
+
+      // ?consolekeys=0|1 — show/hide the console-key row
+      // (START/SELECT/OPTION/>>) independently of the rest of the
+      // touch controls.  A kiosk/arcade shell can launch with
+      // ?consolekeys=0 for games that never use the console switches,
+      // or drive Module._ATWasmSetConsoleKeys at runtime to auto-hide
+      // the row after a few seconds of inactivity.  The hamburger menu
+      // button is unaffected.  Applied via ATWasmSetConsoleKeys once
+      // the runtime is ready.
+      var consoleKeysRaw = (p.get('consolekeys') || '').trim();
+      if (consoleKeysRaw === '0' || consoleKeysRaw === '1') {
+        window.__altirraLib.consolekeys = (consoleKeysRaw === '1');
+        log('consolekeys=' + (window.__altirraLib.consolekeys ? '1' : '0'));
+      } else if (consoleKeysRaw) {
+        log('ignored unknown consolekeys value:', consoleKeysRaw);
       }
 
       // ?stretch=fill|preserve|square|integral|integral_preserve —
@@ -1099,6 +1117,9 @@
     }
     if (lib.vkbd !== null && Module._ATWasmSetVirtualKeyboard) {
       try { Module._ATWasmSetVirtualKeyboard(lib.vkbd ? 1 : 0); } catch (e) {}
+    }
+    if (lib.consolekeys !== null && Module._ATWasmSetConsoleKeys) {
+      try { Module._ATWasmSetConsoleKeys(lib.consolekeys ? 1 : 0); } catch (e) {}
     }
     if (lib.stretch !== null && Module._ATWasmSetStretchMode) {
       try { Module._ATWasmSetStretchMode(lib.stretch); } catch (e) {}

--- a/src/AltirraSDL/source/app/wasm_bridge.cpp
+++ b/src/AltirraSDL/source/app/wasm_bridge.cpp
@@ -77,6 +77,7 @@ extern ATSimulator g_sim;
 // the same way the touch controls + virtual keyboard do.  Through the
 // netplay router so a hosted-session host edge propagates to peers.
 #include "../netplay/netplay_input.h"
+#include "../input/touch_controls.h"
 #include "gtia.h"
 
 // Page-bar toggles (PAL/NTSC, CRT, Virtual Keyboard, Touch Controls,
@@ -1484,6 +1485,21 @@ void ATWasmConsoleSwitch(int bit, int down) {
 	const uint8_t b = (uint8_t)(bit & 0x07);   // mask to START|SELECT|OPTION
 	if (!b) return;
 	ATNetplayInput::RouteConsoleSwitch(&g_sim.GetGTIA(), b, down != 0);
+}
+
+// Show/hide the on-canvas console-key row (START/SELECT/OPTION/>>)
+// independently of the rest of the touch controls (?consolekeys= deep
+// link / embedder JS).  Lets a kiosk/arcade shell keep the joystick +
+// fire visible while auto-hiding the console keys after inactivity, or
+// hide them for games that never use them.  The hamburger menu button
+// is unaffected; hiding releases any currently-held console switch.
+extern "C" EMSCRIPTEN_KEEPALIVE
+int ATWasmGetConsoleKeys() {
+	return ATTouchControls_GetConsoleKeysVisible() ? 1 : 0;
+}
+extern "C" EMSCRIPTEN_KEEPALIVE
+void ATWasmSetConsoleKeys(int on) {
+	ATTouchControls_SetConsoleKeysVisible(on != 0);
 }
 
 // JS-side bar button (RESET) — cold reset.  The HTML page wraps this

--- a/src/AltirraSDL/source/input/touch_controls.cpp
+++ b/src/AltirraSDL/source/input/touch_controls.cpp
@@ -75,6 +75,12 @@ static bool s_selectHeld = false;
 static bool s_optionHeld = false;
 static bool s_warpHeld = false;
 
+// Console-key row visibility (embedder hook — see touch_controls.h).
+// When false the START/SELECT/OPTION/>> buttons are neither drawn nor
+// hit-tested; the hamburger menu button is unaffected.  Default on so
+// nothing changes unless an embedder asks.
+static bool s_consoleKeysVisible = true;
+
 // Menu button tap detection — not static, accessed by ui_mobile.cpp.
 // Set when the user has completed a press-and-release on btnMenu so the
 // menu opens on FINGER_UP (matching every other button on screen) and
@@ -210,6 +216,26 @@ void ATTouchControls_ReleaseAll() {
 	s_menuFingerActive = false;
 	s_menuFinger = 0;
 	s_menuMouseActive = false;
+}
+
+// Embedder hook — see touch_controls.h.  Hiding mid-press releases any
+// held console switch so a key can't stay latched while invisible.
+void ATTouchControls_SetConsoleKeysVisible(bool visible) {
+	if (s_consoleKeysVisible == visible)
+		return;
+	s_consoleKeysVisible = visible;
+
+	if (!visible) {
+		if (s_startHeld)  { SetConsoleSwitch(0x01, false); s_startHeld = false; }
+		if (s_selectHeld) { SetConsoleSwitch(0x02, false); s_selectHeld = false; }
+		if (s_optionHeld) { SetConsoleSwitch(0x04, false); s_optionHeld = false; }
+		if (s_warpHeld)   { ATUISetTurboPulse(false); s_warpHeld = false; }
+		s_consoleActive = false;
+	}
+}
+
+bool ATTouchControls_GetConsoleKeysVisible() {
+	return s_consoleKeysVisible;
 }
 
 bool ATTouchControls_IsActive() {
@@ -356,7 +382,7 @@ bool ATTouchControls_HandleEvent(const SDL_Event &ev, const ATTouchLayout &layou
 			return false;
 
 		// --- CONSOLE KEYS (top bar) ---
-		if (topBarPx.Contains(px, py) && !s_consoleActive) {
+		if (s_consoleKeysVisible && topBarPx.Contains(px, py) && !s_consoleActive) {
 			// Only claim the finger if it actually hits a console button
 			if (layout.btnStart.Contains(px, py)) {
 				s_consoleFinger = fid;
@@ -726,7 +752,7 @@ void ATTouchControls_Render(const ATTouchLayout &layout, const ATTouchLayoutConf
 	// Get foreground draw list (renders on top of everything)
 	ImDrawList *dl = ImGui::GetForegroundDrawList();
 
-	if (showControls) {
+	if (showControls && s_consoleKeysVisible) {
 		// --- Console keys ---
 		DrawButton(dl, layout.btnStart, "START", btnConsole, textColor, s_startHeld);
 		DrawButton(dl, layout.btnSelect, "SELECT", btnConsole, textColor, s_selectHeld);

--- a/src/AltirraSDL/source/input/touch_controls.h
+++ b/src/AltirraSDL/source/input/touch_controls.h
@@ -44,3 +44,12 @@ bool ATTouchControls_IsActive();
 // changes.  When on, every actionable touch triggers an Android
 // Vibrator pulse (via ATAndroid_Vibrate).  Default: on.
 void ATTouchControls_SetHapticEnabled(bool enabled);
+
+// Show/hide the console-key row (START/SELECT/OPTION/>>) independently
+// of the rest of the touch controls.  Embedder hook (e.g. a JS shell
+// that auto-hides the row after a few seconds of inactivity, or shows
+// START only while a game is at its titlescreen).  The hamburger menu
+// button is unaffected.  Hiding releases any currently-held console
+// switch.  Default: visible.
+void ATTouchControls_SetConsoleKeysVisible(bool visible);
+bool ATTouchControls_GetConsoleKeysVisible();


### PR DESCRIPTION
Partial take on item 5 of #81 — gives embedders the console-key visibility primitive without imposing an auto-hide UX in the core.

- `ATTouchControls_SetConsoleKeysVisible(bool)` gates both drawing and hit-testing of the START/SELECT/OPTION/>> row; the hamburger menu button is unaffected, and hiding releases any currently-held console switch so a key can't stay latched while invisible.
- `ATWasmSetConsoleKeys(int)` / `ATWasmGetConsoleKeys()` exports next to `ATWasmConsoleSwitch`.
- `?consolekeys=0|1` in `wasm_lib_deeplink.js`, same pattern as `?vkbd=`.

With this, a shell can launch `?consolekeys=0` for games that never use the switches, or implement auto-hide with a small JS inactivity timer calling `Module._ATWasmSetConsoleKeys(0|1)`. If you'd rather have the auto-hide behavior in the core (the unused `topBarTimer`/`topBarVisible` fields in `ui_mobile.h` look intended for it), happy to rework.

Build-verified with emsdk 5.0.6 (wasm-release preset): links clean, both exports present in the generated loader.

Note: touches the same `wasm_lib_deeplink.js` defaults block as #83 — whichever merges second may need a trivial rebase; I'll handle it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)