### PR TITLE
WASM: add auto-fire for the touch fire button + ATWasmSetAutoFire export

### DIFF
--- a/src/AltirraSDL/cmake/wasm_lib_deeplink.js
+++ b/src/AltirraSDL/cmake/wasm_lib_deeplink.js
@@ -88,6 +88,7 @@
     //   artifact:   0..6|null         (?artifact=none|ntsc|pal|ntschi|palhi|auto|autohi)
     //   vkbd:       true|false|null   (?vkbd=0|1)
     //   consolekeys:true|false|null   (?consolekeys=0|1)
+    //   autofire:   true|false|null   (?autofire=0|1)
     //   stretch:    0..4|null         (?stretch=fill|preserve|square|integral|integral_preserve)
     //   joystick:   0..2|null         (?joystick=analog|dpad8|dpad4)
     //   fullscreen: true|false        (?fullscreen=1)
@@ -102,6 +103,7 @@
     artifact:    null,
     vkbd:        null,
     consolekeys: null,
+    autofire:    null,
     stretch:     null,
     joystick:    null,
     fullscreen:  false,
@@ -522,6 +524,21 @@
         log('consolekeys=' + (window.__altirraLib.consolekeys ? '1' : '0'));
       } else if (consoleKeysRaw) {
         log('ignored unknown consolekeys value:', consoleKeysRaw);
+      }
+
+      // ?autofire=0|1 — auto-fire for the fire button.  When on,
+      // holding fire A pulses the trigger at ~10 Hz instead of a
+      // continuous hold, so shooters that expect repeated taps stay
+      // playable on glass.  A per-game launcher can pass ?autofire=1
+      // for the titles that benefit, or drive Module._ATWasmSetAutoFire
+      // at runtime from its own toggle.  Applied via ATWasmSetAutoFire
+      // once the runtime is ready.
+      var autoFireRaw = (p.get('autofire') || '').trim();
+      if (autoFireRaw === '0' || autoFireRaw === '1') {
+        window.__altirraLib.autofire = (autoFireRaw === '1');
+        log('autofire=' + (window.__altirraLib.autofire ? '1' : '0'));
+      } else if (autoFireRaw) {
+        log('ignored unknown autofire value:', autoFireRaw);
       }
 
       // ?stretch=fill|preserve|square|integral|integral_preserve —
@@ -1156,6 +1173,9 @@
     }
     if (lib.consolekeys !== null && Module._ATWasmSetConsoleKeys) {
       try { Module._ATWasmSetConsoleKeys(lib.consolekeys ? 1 : 0); } catch (e) {}
+    }
+    if (lib.autofire !== null && Module._ATWasmSetAutoFire) {
+      try { Module._ATWasmSetAutoFire(lib.autofire ? 1 : 0); } catch (e) {}
     }
     if (lib.stretch !== null && Module._ATWasmSetStretchMode) {
       try { Module._ATWasmSetStretchMode(lib.stretch); } catch (e) {}

--- a/src/AltirraSDL/source/app/wasm_bridge.cpp
+++ b/src/AltirraSDL/source/app/wasm_bridge.cpp
@@ -1517,6 +1517,21 @@ void ATWasmSetConsoleKeys(int on) {
 	ATMobileUI_SetConsoleKeysEnabled(g_mobileState, on != 0);
 }
 
+// Auto-fire toggle (?autofire= deep link / embedder JS).  When on,
+// holding fire A — the on-screen fire button or the external trigger
+// from ATWasmSetJoystick — pulses the button at ~10 Hz instead of a
+// continuous hold, so shooters that expect repeated taps (rather than
+// a held trigger) stay playable on glass.  Turning it off mid-hold
+// restores the normal continuous hold; fire B (5200) is unaffected.
+extern "C" EMSCRIPTEN_KEEPALIVE
+int ATWasmGetAutoFire() {
+	return ATTouchControls_GetAutoFire() ? 1 : 0;
+}
+extern "C" EMSCRIPTEN_KEEPALIVE
+void ATWasmSetAutoFire(int on) {
+	ATTouchControls_SetAutoFire(on != 0);
+}
+
 // JS-side bar button (RESET) — cold reset.  The HTML page wraps this
 // in a confirm() popup so an accidental click doesn't nuke a save in
 // progress.  Cold reset only — warm reset is rarely useful from the

--- a/src/AltirraSDL/source/input/touch_controls.cpp
+++ b/src/AltirraSDL/source/input/touch_controls.cpp
@@ -74,6 +74,23 @@ static bool s_fireAHeld = false;
 static bool s_fireBHeld = false;
 static bool s_effectiveFireAHeld = false;
 
+// Auto-fire (embedder hook — see touch_controls.h).  When enabled, a
+// held fire A — the touch fire button or the external trigger from
+// ATTouchControls_SetExternalJoystick — is chopped into ~10 Hz down/up
+// pulses instead of a continuous hold.  The pulse timer is advanced
+// once per frame from ATTouchControls_Render; the phase itself lives
+// in UpdateEffectiveJoystick so touch events, the external trigger,
+// and the timer all share one edge-forwarding code path.
+static bool s_autoFireEnabled = false;
+static bool s_autoFirePulsing = false;    // A held fire A is currently being pulsed
+static bool s_autoFirePhaseDown = false;  // Current phase of the pulse square wave
+static Uint64 s_autoFireNextFlip = 0;     // SDL_GetTicks() time of the next phase flip
+
+// Half-period of the auto-fire square wave: 50 ms down + 50 ms up
+// = 10 Hz, comfortably above the ~6 Hz a human sustains by tapping
+// but slow enough that every pulse spans several frames at 50/60 Hz.
+static const Uint64 kAutoFireHalfPeriodMs = 50;
+
 // Console button tracking (START/SELECT/OPTION/WARP each track independently)
 static SDL_FingerID s_consoleFinger = 0;
 static bool s_consoleActive = false;
@@ -173,7 +190,31 @@ static void UpdateEffectiveJoystick() {
 		s_effectiveJoyDirMask = newMask;
 	}
 
-	const bool fireA = s_fireAHeld || s_extTrigHeld;
+	const bool fireHeld = s_fireAHeld || s_extTrigHeld;
+	bool fireA = fireHeld;
+
+	if (s_autoFireEnabled && fireHeld) {
+		// Auto-fire: replace the continuous hold with a square wave.
+		// Start (or restart) in the DOWN phase so the first shot is
+		// instant, then flip every half-period.  Releasing takes the
+		// `else` branch below, so a release always ends with the
+		// button up regardless of phase; disabling auto-fire mid-hold
+		// falls through with fireA = fireHeld = true, restoring the
+		// normal continuous hold.
+		const Uint64 now = SDL_GetTicks();
+		if (!s_autoFirePulsing) {
+			s_autoFirePulsing = true;
+			s_autoFirePhaseDown = true;
+			s_autoFireNextFlip = now + kAutoFireHalfPeriodMs;
+		} else if (now >= s_autoFireNextFlip) {
+			s_autoFirePhaseDown = !s_autoFirePhaseDown;
+			s_autoFireNextFlip = now + kAutoFireHalfPeriodMs;
+		}
+		fireA = s_autoFirePhaseDown;
+	} else {
+		s_autoFirePulsing = false;
+	}
+
 	if (fireA != s_effectiveFireAHeld) {
 		if (s_pInputManager) {
 			if (fireA)
@@ -277,6 +318,21 @@ void ATTouchControls_SetConsoleKeysVisible(bool visible) {
 
 bool ATTouchControls_GetConsoleKeysVisible() {
 	return s_consoleKeysVisible;
+}
+
+// Embedder hook — see touch_controls.h.  Toggling mid-hold re-runs the
+// effective-state update immediately: enabling starts pulsing from a
+// fresh DOWN phase, disabling restores the normal continuous hold
+// without dropping the press.
+void ATTouchControls_SetAutoFire(bool enabled) {
+	if (s_autoFireEnabled == enabled)
+		return;
+	s_autoFireEnabled = enabled;
+	UpdateEffectiveJoystick();
+}
+
+bool ATTouchControls_GetAutoFire() {
+	return s_autoFireEnabled;
 }
 
 bool ATTouchControls_IsActive() {
@@ -773,6 +829,15 @@ static void DrawJoystick(ImDrawList *dl, float baseX, float baseY,
 void ATTouchControls_Render(const ATTouchLayout &layout, const ATTouchLayoutConfig &config,
 	bool showControls, bool showMenu)
 {
+	// Advance the auto-fire pulse.  Render runs once per frame, which
+	// is the only per-frame entry point the touch layer has; the flip
+	// itself happens inside UpdateEffectiveJoystick so the timer and
+	// the event-driven state changes share one code path.  Placed
+	// before the visibility early-out so an external trigger (which
+	// works with the controls hidden) keeps pulsing too.
+	if (s_autoFireEnabled && (s_fireAHeld || s_extTrigHeld))
+		UpdateEffectiveJoystick();
+
 	if (!showControls && !showMenu)
 		return;
 

--- a/src/AltirraSDL/source/input/touch_controls.h
+++ b/src/AltirraSDL/source/input/touch_controls.h
@@ -66,3 +66,16 @@ void ATTouchControls_SetExternalJoystick(uint8 dirMask, bool trigger);
 // switch.  Default: visible.
 void ATTouchControls_SetConsoleKeysVisible(bool visible);
 bool ATTouchControls_GetConsoleKeysVisible();
+
+// Enable/disable auto-fire for fire A.  Embedder hook (e.g. a JS
+// shell offering an auto-fire toggle for shooters, sparing thumbs on
+// glass with no tactile trigger).  When on, holding fire A — the
+// on-screen fire button or the external trigger from
+// ATTouchControls_SetExternalJoystick — pulses the button at ~10 Hz
+// instead of a continuous hold.  Turning it off mid-hold restores the
+// normal hold without dropping the press; releasing the finger always
+// ends with the button up; ATTouchControls_ReleaseAll() clears any
+// pulse in flight.  Fire B (5200 second trigger) is unaffected.
+// Default: off.
+void ATTouchControls_SetAutoFire(bool enabled);
+bool ATTouchControls_GetAutoFire();


### PR DESCRIPTION
Follow-up to the #81 embedder-hook series (#82–#84). When enabled, holding fire A — the on-screen fire button or the external trigger from `ATWasmSetJoystick` — pulses the button at ~10 Hz (50 ms down / 50 ms up, instant first shot) instead of a continuous hold, so shooters that expect repeated taps stay playable on glass.

- Pulse phase lives in `UpdateEffectiveJoystick` so touch events, the external trigger, and the per-frame timer share the existing edge-forwarding path; timer advanced from `ATTouchControls_Render`.
- Safe edges: releasing always ends with the button up; disabling mid-hold restores the normal continuous hold without dropping the press; `ATTouchControls_ReleaseAll` clears any pulse in flight. Fire B (5200) unaffected.
- `ATWasmSetAutoFire(int)` / `ATWasmGetAutoFire()` exports next to `ATWasmSetConsoleKeys`, plus `?autofire=0|1` in `wasm_lib_deeplink.js`, same pattern as `?consolekeys=`.

Build-verified with emsdk 5.0.6 (wasm-release preset): links clean, both exports present in the generated loader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)