### PR TITLE
Fix NetSIO and custom device network connectivity on Windows

### DIFF
--- a/src/ATCore/CMakeLists.txt
+++ b/src/ATCore/CMakeLists.txt
@@ -71,9 +71,8 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND
         COMPILE_FLAGS "-march=armv8-a+crypto")
 endif()
 
-# Windows-only timer service — excluded when ALTIRRA_SDL3 is ON because
-# win32_stubs.cpp provides ATCreateTimerService() as a stub.
-if(WIN32 AND NOT ALTIRRA_SDL3)
+# Windows-only timer service using native threadpool timers.
+if(WIN32)
     list(APPEND ATCORE_COMMON_SOURCES
         source/timerserviceimpl_win32.cpp
     )

--- a/src/Altirra/source/customdevice_win32.cpp
+++ b/src/Altirra/source/customdevice_win32.cpp
@@ -91,7 +91,7 @@ void ATDeviceCustomNetworkEngine::Shutdown() {
 
 bool ATDeviceCustomNetworkEngine::IsConnected() {
 	mMutex.Lock();
-	bool success = mpSocket && (!mSocketStatus.mbConnecting && !mSocketStatus.mbClosed);
+	bool success = mpSocket && (!mSocketStatus.mbConnecting && !mSocketStatus.mbClosed && !mSocketStatus.mbRemoteClosed);
 	mMutex.Unlock();
 
 	return success;
@@ -102,7 +102,9 @@ bool ATDeviceCustomNetworkEngine::WaitForFirstConnectionAttempt() {
 
 	for(;;) {
 		vdsynchronized(mMutex) {
-			success = mpSocket && !mSocketStatus.mbConnecting;
+			if (!mpSocket)
+				return false;
+			success = !mSocketStatus.mbConnecting;
 		}
 
 		if (success)
@@ -120,7 +122,7 @@ bool ATDeviceCustomNetworkEngine::Restore() {
 	if (mpSocket) {
 		vdsynchronized(mMutex) {
 			if (mbRestoreRequired) {
-				if (!mSocketStatus.mbConnecting && !mSocketStatus.mbClosed) {
+				if (!mSocketStatus.mbConnecting && !mSocketStatus.mbClosed && !mSocketStatus.mbRemoteClosed) {
 					mbRestoreRequired = false;
 					success = true;
 				}
@@ -234,7 +236,7 @@ void ATDeviceCustomNetworkEngine::Connect() {
 				vdsynchronized(mMutex) {
 					mSocketStatus = status;
 
-					if (status.mbClosed)
+					if (status.mbClosed || status.mbRemoteClosed)
 						mbRestoreRequired = true;
 					else if ((status.mbCanRead && mbRecvNotifyNeeded) || (!status.mbConnecting && mbInitialNotifyNeeded)) {
 						mbRecvNotifyNeeded = false;
@@ -248,7 +250,7 @@ void ATDeviceCustomNetworkEngine::Connect() {
 
 				mSocketEvent.signal();
 
-				if (status.mbClosed)
+				if (status.mbClosed || status.mbRemoteClosed)
 					QueueReconnect();
 			},
 			true
@@ -271,7 +273,7 @@ void ATDeviceCustomNetworkEngine::QueueReconnect() {
 				bool socketClosed;
 
 				vdsynchronized(mMutex) {
-					socketClosed = mSocketStatus.mbClosed;
+					socketClosed = mSocketStatus.mbClosed || mSocketStatus.mbRemoteClosed;
 				}
 
 				if (socketClosed) {

--- a/src/AltirraBridgeServer/main_bridge.cpp
+++ b/src/AltirraBridgeServer/main_bridge.cpp
@@ -629,6 +629,7 @@ static void BridgePollUntil(std::chrono::steady_clock::time_point deadline) {
 			? tickDeadline
 			: deadline);
 		ATBridge::Poll(g_sim, g_uiState);
+		g_sim.OnWake();
 	}
 }
 
@@ -727,6 +728,7 @@ int main(int argc, char** argv) {
 		// 1. Process bridge commands (non-blocking, capped at 64
 		//    commands/poll).
 		ATBridge::Poll(g_sim, g_uiState);
+		g_sim.OnWake();
 
 		// 2. Tick the simulator until a real frame is produced or
 		//    the simulator stops. With SetFrameSkip(true), GTIA
@@ -778,9 +780,11 @@ int main(int argc, char** argv) {
 		//    round-trips do not wait for a full frame.
 		if (result == ATSimulator::kAdvanceResult_Stopped) {
 			std::this_thread::sleep_for(std::chrono::microseconds(500));
+			g_sim.OnWake();
 			nextFrameDeadline = clock::now() + BridgeGetFrameDuration();
 		} else if (result == ATSimulator::kAdvanceResult_WaitingForFrame && !framePosted) {
 			std::this_thread::sleep_for(std::chrono::microseconds(500));
+			g_sim.OnWake();
 			nextFrameDeadline = clock::now() + BridgeGetFrameDuration();
 		}
 	}

--- a/src/AltirraBridgeServer/stubs/SDL3/SDL.h
+++ b/src/AltirraBridgeServer/stubs/SDL3/SDL.h
@@ -38,8 +38,107 @@ inline void SDL_free(void*) {}
 inline bool SDL_OpenURL(const char*) { return false; }
 
 // Timers
-inline SDL_TimerID SDL_AddTimer(Uint32, SDL_TimerCallback, void*) { return 0; }
-inline bool SDL_RemoveTimer(SDL_TimerID) { return false; }
+#include <thread>
+#include <mutex>
+#include <condition_variable>
+#include <map>
+#include <chrono>
+
+namespace HeadlessSDLTimer {
+	struct TimerEntry {
+		SDL_TimerID id;
+		std::chrono::steady_clock::time_point fireTime;
+		Uint32 interval;
+		SDL_TimerCallback cb;
+		void *param;
+	};
+
+	inline std::mutex& GetMutex() {
+		static std::mutex m;
+		return m;
+	}
+	inline std::condition_variable& GetCV() {
+		static std::condition_variable cv;
+		return cv;
+	}
+	inline std::map<SDL_TimerID, TimerEntry>& GetTimers() {
+		static std::map<SDL_TimerID, TimerEntry> timers;
+		return timers;
+	}
+	inline bool& GetRunning() {
+		static bool running = false;
+		return running;
+	}
+	inline std::thread*& GetThread() {
+		static std::thread *t = nullptr;
+		return t;
+	}
+	inline SDL_TimerID& GetNextID() {
+		static SDL_TimerID nextID = 1;
+		return nextID;
+	}
+
+	inline void WorkerThread() {
+		std::unique_lock<std::mutex> lock(GetMutex());
+		while (GetRunning()) {
+			if (GetTimers().empty()) {
+				GetCV().wait(lock, [] { return !GetRunning() || !GetTimers().empty(); });
+			} else {
+				auto nextIt = GetTimers().begin();
+				for (auto it = GetTimers().begin(); it != GetTimers().end(); ++it) {
+					if (it->second.fireTime < nextIt->second.fireTime)
+						nextIt = it;
+				}
+				auto now = std::chrono::steady_clock::now();
+				if (now >= nextIt->second.fireTime) {
+					TimerEntry entry = nextIt->second;
+					GetTimers().erase(nextIt);
+					lock.unlock();
+					Uint32 nextInterval = entry.cb(entry.param, entry.id, entry.interval);
+					lock.lock();
+					if (nextInterval > 0) {
+						entry.interval = nextInterval;
+						entry.fireTime = std::chrono::steady_clock::now() + std::chrono::milliseconds(nextInterval);
+						GetTimers()[entry.id] = entry;
+					}
+				} else {
+					GetCV().wait_until(lock, nextIt->second.fireTime);
+				}
+			}
+		}
+	}
+}
+
+inline SDL_TimerID SDL_AddTimer(Uint32 interval, SDL_TimerCallback callback, void* userdata) {
+	if (!callback || interval == 0) return 0;
+	std::lock_guard<std::mutex> lock(HeadlessSDLTimer::GetMutex());
+	if (!HeadlessSDLTimer::GetRunning()) {
+		HeadlessSDLTimer::GetRunning() = true;
+		HeadlessSDLTimer::GetThread() = new std::thread(HeadlessSDLTimer::WorkerThread);
+	}
+	SDL_TimerID id = HeadlessSDLTimer::GetNextID()++;
+	HeadlessSDLTimer::TimerEntry entry;
+	entry.id = id;
+	entry.interval = interval;
+	entry.fireTime = std::chrono::steady_clock::now() + std::chrono::milliseconds(interval);
+	entry.cb = callback;
+	entry.param = userdata;
+	HeadlessSDLTimer::GetTimers()[id] = entry;
+	HeadlessSDLTimer::GetCV().notify_one();
+	return id;
+}
+
+inline bool SDL_RemoveTimer(SDL_TimerID id) {
+	if (id == 0) return false;
+	std::lock_guard<std::mutex> lock(HeadlessSDLTimer::GetMutex());
+	auto it = HeadlessSDLTimer::GetTimers().find(id);
+	if (it != HeadlessSDLTimer::GetTimers().end()) {
+		HeadlessSDLTimer::GetTimers().erase(it);
+		HeadlessSDLTimer::GetCV().notify_one();
+		return true;
+	}
+	return false;
+}
 
 // Message box
 enum { SDL_MESSAGEBOX_INFORMATION = 0, SDL_MESSAGEBOX_WARNING = 1, SDL_MESSAGEBOX_ERROR = 2 };

--- a/src/AltirraSDL/source/bridge/tests/bridge_custom_device_test.py
+++ b/src/AltirraSDL/source/bridge/tests/bridge_custom_device_test.py
@@ -265,13 +265,16 @@ def main() -> int:
                 bridge.device_remove("printer")
                 bridge.quit()
         finally:
-            if proc.poll() is None:
-                proc.terminate()
             try:
-                proc.wait(timeout=10)
-            except subprocess.TimeoutExpired:
-                proc.kill()
                 proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                if proc.poll() is None:
+                    proc.terminate()
+                try:
+                    proc.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    proc.wait(timeout=5)
             stderr_thread.join(timeout=1)
 
         if proc.returncode not in (0, -15):

--- a/src/AltirraSDL/stubs/win32_stubs.cpp
+++ b/src/AltirraSDL/stubs/win32_stubs.cpp
@@ -128,9 +128,11 @@ void ATAsyncDownloadUrl(const wchar_t *url, const wchar_t *userAgent, size_t max
 // UI accessor stubs are now in uiaccessors_stubs.cpp.
 
 // ============================================================
-// ATTimerService — SDL3 implementation
+// ATTimerService — SDL3 implementation (non-Windows only;
+// Windows uses native threadpool timers in ATCore)
 // ============================================================
 
+#if !defined(_WIN32)
 class ATTimerServiceSDL3 final : public IATTimerService {
 public:
 	ATTimerServiceSDL3(IATAsyncDispatcher& disp) : mpDispatcher(&disp) {}
@@ -200,6 +202,7 @@ private:
 IATTimerService *ATCreateTimerService(IATAsyncDispatcher& disp) {
 	return new ATTimerServiceSDL3(disp);
 }
+#endif
 
 // ============================================================
 // ATGetNameForWindowMessageW32 stub

--- a/src/h/vd2/system/thread.h
+++ b/src/h/vd2/system/thread.h
@@ -185,6 +185,69 @@ public:
 
 ///////////////////////////////////////////////////////////////////////////
 
+#if defined(VD_OS_WINDOWS) || defined(_WIN32)
+
+class VDSignalBase {
+	VDSignalBase(const VDSignalBase&) = delete;
+	VDSignalBase& operator=(const VDSignalBase&) = delete;
+protected:
+	void *hEvent;
+
+	VDSignalBase(bool manualReset, bool initialState);
+
+public:
+	VDSignalBase();
+	~VDSignalBase();
+
+	void signal();
+	bool check();
+	void wait();
+	int wait(VDSignalBase *second);
+	int wait(VDSignalBase *second, VDSignalBase *third);
+	static int waitMultiple(const VDSignalBase *const *signals, int count);
+
+	bool tryWait(uint32 timeoutMillisec);
+
+	void *getHandle() { return hEvent; }
+	const void *getHandle() const { return hEvent; }
+
+	void operator()() { signal(); }
+};
+
+class VDSignal : public VDSignalBase {
+public:
+	VDSignal();
+};
+
+class VDSignalPersistent : public VDSignalBase {
+public:
+	VDSignalPersistent();
+
+	void unsignal();
+};
+
+///////////////////////////////////////////////////////////////////////////
+
+class VDSemaphore {
+public:
+	VDSemaphore(int initial);
+	~VDSemaphore();
+
+	void *GetHandle() const { return mKernelSema; }
+
+	void Reset(int count);
+
+	void Wait();
+	bool Wait(int timeout);
+	bool TryWait();
+	void Post();
+
+private:
+	void *mKernelSema;
+};
+
+#else
+
 class VDSignalBase {
 	VDSignalBase(const VDSignalBase&) = delete;
 	VDSignalBase& operator=(const VDSignalBase&) = delete;
@@ -208,6 +271,7 @@ public:
 	bool tryWait(uint32 timeoutMillisec);
 
 	void *getHandle() { return nullptr; }
+	const void *getHandle() const { return nullptr; }
 
 	void operator()() { signal(); }
 };
@@ -245,6 +309,8 @@ private:
 	std::condition_variable mCondVar;
 	int mCount;
 };
+
+#endif
 
 ///////////////////////////////////////////////////////////////////////////
 

--- a/src/system/source/thread.cpp
+++ b/src/system/source/thread.cpp
@@ -326,7 +326,119 @@ void *VDThread::StaticThreadStart(void *pThisAsVoid) {
 #endif
 
 ///////////////////////////////////////////////////////////////////////////
-// VDSignalBase - portable implementation using std::mutex + std::condition_variable
+// VDSignalBase / VDSemaphore
+
+#if defined(VD_OS_WINDOWS) || defined(_WIN32)
+
+VDSignalBase::VDSignalBase() {
+	hEvent = (void *)CreateEvent(NULL, FALSE, FALSE, NULL);
+}
+
+VDSignalBase::VDSignalBase(bool manualReset, bool initialState) {
+	hEvent = (void *)CreateEvent(NULL, manualReset ? TRUE : FALSE, initialState ? TRUE : FALSE, NULL);
+}
+
+VDSignalBase::~VDSignalBase() {
+	if (hEvent) {
+		CloseHandle((HANDLE)hEvent);
+		hEvent = nullptr;
+	}
+}
+
+VDSignal::VDSignal()
+	: VDSignalBase(false, false)
+{
+}
+
+VDSignalPersistent::VDSignalPersistent()
+	: VDSignalBase(true, false)
+{
+}
+
+void VDSignalBase::signal() {
+	SetEvent((HANDLE)hEvent);
+}
+
+bool VDSignalBase::check() {
+	return WaitForSingleObject((HANDLE)hEvent, 0) == WAIT_OBJECT_0;
+}
+
+void VDSignalBase::wait() {
+	WaitForSingleObject((HANDLE)hEvent, INFINITE);
+}
+
+int VDSignalBase::wait(VDSignalBase *second) {
+	HANDLE h[2] = { (HANDLE)hEvent, (HANDLE)second->hEvent };
+	DWORD res = WaitForMultipleObjects(2, h, FALSE, INFINITE);
+	if (res >= WAIT_OBJECT_0 && res < WAIT_OBJECT_0 + 2)
+		return (int)(res - WAIT_OBJECT_0);
+	return -1;
+}
+
+int VDSignalBase::wait(VDSignalBase *second, VDSignalBase *third) {
+	HANDLE h[3] = { (HANDLE)hEvent, (HANDLE)second->hEvent, (HANDLE)third->hEvent };
+	DWORD res = WaitForMultipleObjects(3, h, FALSE, INFINITE);
+	if (res >= WAIT_OBJECT_0 && res < WAIT_OBJECT_0 + 3)
+		return (int)(res - WAIT_OBJECT_0);
+	return -1;
+}
+
+int VDSignalBase::waitMultiple(const VDSignalBase *const *signals, int count) {
+	if (count <= 0)
+		return -1;
+	if (count > MAXIMUM_WAIT_OBJECTS)
+		count = MAXIMUM_WAIT_OBJECTS;
+	HANDLE h[MAXIMUM_WAIT_OBJECTS];
+	for (int i = 0; i < count; ++i)
+		h[i] = (HANDLE)signals[i]->hEvent;
+	DWORD res = WaitForMultipleObjects(count, h, FALSE, INFINITE);
+	if (res >= WAIT_OBJECT_0 && res < WAIT_OBJECT_0 + (DWORD)count)
+		return (int)(res - WAIT_OBJECT_0);
+	return -1;
+}
+
+bool VDSignalBase::tryWait(uint32 timeoutMillisec) {
+	return WaitForSingleObject((HANDLE)hEvent, timeoutMillisec) == WAIT_OBJECT_0;
+}
+
+void VDSignalPersistent::unsignal() {
+	ResetEvent((HANDLE)hEvent);
+}
+
+VDSemaphore::VDSemaphore(int initial) {
+	mKernelSema = (void *)CreateSemaphore(NULL, initial, 0x7fffffff, NULL);
+}
+
+VDSemaphore::~VDSemaphore() {
+	if (mKernelSema) {
+		CloseHandle((HANDLE)mKernelSema);
+		mKernelSema = nullptr;
+	}
+}
+
+void VDSemaphore::Reset(int count) {
+	if (mKernelSema)
+		CloseHandle((HANDLE)mKernelSema);
+	mKernelSema = (void *)CreateSemaphore(NULL, count, 0x7fffffff, NULL);
+}
+
+void VDSemaphore::Wait() {
+	WaitForSingleObject((HANDLE)mKernelSema, INFINITE);
+}
+
+bool VDSemaphore::Wait(int timeout) {
+	return WaitForSingleObject((HANDLE)mKernelSema, timeout) == WAIT_OBJECT_0;
+}
+
+bool VDSemaphore::TryWait() {
+	return WaitForSingleObject((HANDLE)mKernelSema, 0) == WAIT_OBJECT_0;
+}
+
+void VDSemaphore::Post() {
+	ReleaseSemaphore((HANDLE)mKernelSema, 1, NULL);
+}
+
+#else // non-Windows
 
 VDSignal::VDSignal() {
 	mAutoReset = true;
@@ -451,6 +563,8 @@ void VDSemaphore::Post() {
 	}
 	mCondVar.notify_one();
 }
+
+#endif
 
 ///////////////////////////////////////////////////////////////////////////
 // VDConditionVariable - wraps std::condition_variable_any


### PR DESCRIPTION
### Summary

Fixes an issue where custom devices with network capability (such as `netsio.atdevice` communicating with FujiNet-PC on TCP port 9996) failed to open sockets on Windows, reporting:
```json
"healthy": false,
"diagnostics": ["No connection to device server. Custom device may not function properly."]
```

### Root Cause
- In `src/h/vd2/system/thread.h`, `VDSignalBase::getHandle()` returned `nullptr` after the portable `std::mutex` rewrite. On Windows, `ATNetworkSockets` (`socketworker.cpp`) calls `WSAEventSelect(mSocketHandle, mSocketSignal.getHandle(), ...)`. Passing `NULL` with event flags fails with `WSAEINVAL` (10022), aborting socket initialization before `connect()` can be issued.
- Reconnect timers were not executing on Windows in `AltirraBridgeServer` due to CMake conditions excluding `timerserviceimpl_win32.cpp`.
- `ATDeviceCustomNetworkEngine` only checked `mSocketStatus.mbClosed` (local closure) and ignored `mbRemoteClosed` (remote server disconnection).

### Key Changes
- **`src/h/vd2/system/thread.h` & `src/system/source/thread.cpp`**: Restored Win32 `hEvent` / `mKernelSema` implementation of `VDSignalBase`, `VDSignal`, `VDSignalPersistent`, and `VDSemaphore` under `#if defined(VD_OS_WINDOWS) || defined(_WIN32)`, keeping the portable `std::condition_variable` implementation for non-Windows.
- **`src/ATCore/CMakeLists.txt` & `src/AltirraSDL/stubs/win32_stubs.cpp`**: Enabled `timerserviceimpl_win32.cpp` for all Windows targets (`if(WIN32)`), guarding `ATTimerServiceSDL3` with `#if !defined(_WIN32)`.
- **`src/AltirraBridgeServer/stubs/SDL3/SDL.h`**: Implemented `HeadlessSDLTimer` worker thread fallback for environments without SDL3.
- **`src/Altirra/source/customdevice_win32.cpp`**: Added `if (!mpSocket) return false;` in `WaitForFirstConnectionAttempt()` and added `mbRemoteClosed` handling.
- **`src/AltirraBridgeServer/main_bridge.cpp`**: Added `g_sim.OnWake()` in `BridgePollUntil()` and idle sleep branches.
- **`src/AltirraSDL/source/bridge/tests/bridge_custom_device_test.py`**: Added graceful wait before process termination.

### Verification
1. **Integration Tests**: `bridge_custom_device_test.py` passed with exit code 0.
2. **Socket Verification**: `netstat` / `Get-NetTCPConnection` confirmed state `Established` to FujiNet hub `127.0.0.1:9996`, `healthy: true`, `diagnostics: []`.
3. **End-to-End Boot & TNFS Browsing**:
   - Atari XL booted from FujiNet's internal autorun config disk over SIO (`--pacing=realtime`, `siopatch: off`).
   - FujiNet configuration loaded, selected slot 2 (`FUJINET.PL`), sent `RETURN` (`Browse`).
   - Retrieved full directory listing from TNFS `fujinet.pl` (`anode/`, `demoscene/`, `fish/`, `games/`, etc.).