### PR TITLE
bridge: the 65C816's registers in REGS and HISTORY, CONFIG history, and a large-reply flush fix

### DIFF
--- a/src/AltirraSDL/AltirraBridge/docs/PROTOCOL.md
+++ b/src/AltirraSDL/AltirraBridge/docs/PROTOCOL.md
@@ -242,6 +242,19 @@ CPU registers, decoded status flags, cycle counter, and CPU mode.
 | `cycles` | integer | Cycle counter since last reset. Wraps at 2³² (~71 minutes). |
 | `mode`   | string  | `"6502"`, `"65C02"`, or `"65C816"`.                         |
 
+When `mode` is `"65C816"` the reply carries the rest of that CPU's
+state as well, without which a native-mode `PC` or `S` is a 16-bit
+truncation of where the machine really is:
+
+| Field    | Type    | Notes                                                       |
+|----------|---------|-------------------------------------------------------------|
+| `K`      | hex8    | Program bank: `PC` is at `K:PC`.                            |
+| `B`      | hex8    | Data bank.                                                  |
+| `D`      | hex16   | Direct page.                                                |
+| `SH`     | hex8    | High byte of the 16-bit stack pointer: `S` is at `SH:S`.    |
+| `AH`/`XH`/`YH` | hex8 | High bytes of the 16-bit accumulator and index registers. |
+| `E`      | integer | Emulation flag: 1 in emulation mode, 0 in native mode.      |
+
 The `flags` string is `NV-BDIZC` for 6502/65C02/65C816 emulation mode
 and `NVMXDIZC` for 65C816 native mode (bits 4-5 are X/M instead of
 B/unused). Set bits are uppercase letters; clear bits are `-`.
@@ -767,6 +780,7 @@ Set a config key. Returns the full config state after the set.
 | `kernel`      | `default`, `lle`, `llexl`, `hle`, `osa`, `osb`, `xl`, path/id   | Triggers cold reset         |
 | `basicrom`    | `default`, `atbasic`, `reva`, `revb`, `revc`, path/id           | Triggers cold reset         |
 | `debugbrkrun` | `true`, `false`, `on`, `off`, `1`, `0`                          | Break at EXE run address    |
+| `history`     | `true`, `false`, `on`, `off`, `1`, `0`                          | CPU instruction history recording, which `HISTORY` reads; off by default |
 
 Memory modes: `8K`, `16K`, `24K`, `32K`, `40K`, `48K`, `52K`, `64K`,
 `128K`, `256K`, `320K`, `320K_Compy`, `576K`, `576K_Compy`, `1088K`.
@@ -951,6 +965,19 @@ primitive AltirraBridge exposes.**
    "a":"$ff","x":"$ff","y":"$17","s":"$f3","p":"$b1","ea":"$0014",
    "irq":false,"nmi":false}
 ]}
+```
+
+Recording is off unless it has been turned on: `CONFIG history true`
+before the run, `HISTORY n` after it. On a 65C816 each entry also
+carries `k` (the program bank the instruction ran in), `b` (the data
+bank), `sh` (the high byte of the stack pointer), `e` (the emulation
+flag) and `bytes`, the instruction's four bytes, from which a client
+can disassemble what actually ran:
+
+```json
+{"cycle":143006197,"pc":"$ff36","op":"$ad","k":"$01","b":"$00",
+ "sh":"$32","e":0,"bytes":"ad0ed249","a":"$00","x":"$74","y":"$44",
+ "s":"$4a","p":"$37","ea":"$d20e","irq":false,"nmi":false}
 ```
 
 #### `EVAL expr`

--- a/src/AltirraSDL/AltirraBridge/sdk/python/altirra_bridge/client.py
+++ b/src/AltirraSDL/AltirraBridge/sdk/python/altirra_bridge/client.py
@@ -287,6 +287,12 @@ class AltirraBridge:
         ``flags`` (8-char string like ``"N--B-IZC"``), ``cycles``
         (integer cycle counter since reset), ``mode``
         (``"6502"`` / ``"65C02"`` / ``"65C816"``).
+
+        On a 65C816 the reply also carries ``K`` (program bank),
+        ``B`` (data bank), ``D`` (direct page), ``SH`` (high byte of
+        the stack pointer), ``AH``/``XH``/``YH`` (high bytes of the
+        16-bit registers) and ``E`` (1 in emulation mode, 0 in
+        native mode).
         """
         return self._cmd_ok("REGS")
 
@@ -904,11 +910,16 @@ class AltirraBridge:
     def history(self, count: int = 64) -> list:
         """Return the last ``count`` CPU history entries, oldest
         first. Each entry has ``cycle``, ``pc``, ``op``,
-        ``a``/``x``/``y``/``s``/``p``, ``ea``, ``irq``, ``nmi``.
+        ``a``/``x``/``y``/``s``/``p``, ``ea``, ``irq``, ``nmi``; on a
+        65C816, also ``k`` (program bank), ``b`` (data bank), ``sh``
+        (high byte of the stack pointer), ``e`` (emulation flag) and
+        ``bytes``, the instruction's four bytes.
 
-        Altirra keeps a 131072-entry ring buffer; ``count`` is capped
-        server-side at 4096. This is the single biggest RE primitive
-        AltirraBridge exposes over the pyA8 reference.
+        Recording is off by default: ``config("history", "true")``
+        before the run, ``history(n)`` after it. Altirra keeps a
+        131072-entry ring buffer; ``count`` is capped server-side at
+        4096. This is the single biggest RE primitive AltirraBridge
+        exposes over the pyA8 reference.
         """
         resp = self._cmd_ok(f"HISTORY {count}")
         return resp.get("entries", [])

--- a/src/AltirraSDL/source/bridge/bridge_commands_debug.cpp
+++ b/src/AltirraSDL/source/bridge/bridge_commands_debug.cpp
@@ -251,6 +251,19 @@ std::string CmdHistory(ATSimulator& sim, const std::vector<std::string>& tokens)
 		AddField(e, "ea",       Hex16(h.mEA & 0xffff));
 		AddBool (e, "irq",      h.mbIRQ);
 		AddBool (e, "nmi",      h.mbNMI);
+		if (cpu.GetCPUMode() == kATCPUMode_65C816) {
+			// The 65C816's side of an entry: the program bank the PC is
+			// in, the data bank, the high byte of S, the emulation flag
+			// and the instruction's bytes, so a client can disassemble.
+			AddField(e, "k",    Hex8(h.mK));
+			AddField(e, "b",    Hex8(h.mB));
+			AddField(e, "sh",   Hex8(h.mExt.mSH));
+			AddU32  (e, "e",    h.mbEmulation ? 1 : 0);
+			char bytes[16];
+			std::snprintf(bytes, sizeof bytes, "\"%02x%02x%02x%02x\"",
+			              h.mOpcode[0], h.mOpcode[1], h.mOpcode[2], h.mOpcode[3]);
+			AddField(e, "bytes", bytes);
+		}
 		StripTrailingComma(e);
 		entries += e;
 		entries += '}';

--- a/src/AltirraSDL/source/bridge/bridge_commands_state.cpp
+++ b/src/AltirraSDL/source/bridge/bridge_commands_state.cpp
@@ -127,6 +127,19 @@ std::string BuildCpuPayload(ATSimulator& sim) {
 	AddField(body, "Y",  Hex8(cpu.GetY()));
 	AddField(body, "S",  Hex8(cpu.GetS()));
 	AddField(body, "P",  Hex8(p));
+	if (cpu.GetCPUMode() == kATCPUMode_65C816) {
+		// The 65C816's other half: the bank registers, the direct page,
+		// the high bytes of the 16-bit registers and the emulation flag.
+		// PC is bank K; S, A, X and Y are 16 bits wide in native mode.
+		AddField(body, "K",  Hex8(cpu.GetK()));
+		AddField(body, "B",  Hex8(cpu.GetB()));
+		AddField(body, "D",  Hex16(cpu.GetD()));
+		AddField(body, "SH", Hex8(cpu.GetSH()));
+		AddField(body, "AH", Hex8(cpu.GetAH()));
+		AddField(body, "XH", Hex8(cpu.GetXH()));
+		AddField(body, "YH", Hex8(cpu.GetYH()));
+		AddU32  (body, "E",  cpu.GetEmulationFlag() ? 1 : 0);
+	}
 	body += "\"flags\":\"";
 	body += flagStr;
 	body += "\",";

--- a/src/AltirraSDL/source/bridge/bridge_commands_write.cpp
+++ b/src/AltirraSDL/source/bridge/bridge_commands_write.cpp
@@ -1133,6 +1133,8 @@ std::string BuildConfigPayload(ATSimulator& sim) {
 	}
 	payload += "\"debugbrkrun\":";
 	payload += (dbg && dbg->IsBreakOnEXERunAddrEnabled() ? "true" : "false");
+	payload += ",\"history\":";
+	payload += (sim.GetCPU().IsHistoryEnabled() ? "true" : "false");
 	return payload;
 }
 
@@ -1967,6 +1969,7 @@ std::string CmdWarmReset(ATSimulator& sim, const std::vector<std::string>& /*tok
 //   kernel      default/path/id SetKernel / GetKernelId
 //   basicrom    default/path/id SetBasic / GetBasicId
 //   debugbrkrun true/false      SetBreakOnEXERunAddrEnabled
+//   history     true/false      ATCPUEmulator::SetHistoryEnabled
 //
 // Setting machine or memory triggers a cold reset (the simulator
 // requires it — the memory layout changes). The pause state is
@@ -2013,6 +2016,8 @@ std::string CmdConfig(ATSimulator& sim, const std::vector<std::string>& tokens) 
 			return JsonOk(std::string("\"selftest\":") + (sim.IsForcedSelfTest() ? "true" : "false"));
 		if (key == "fastboot")
 			return JsonOk(std::string("\"fastboot\":") + (sim.IsFastBootEnabled() ? "true" : "false"));
+		if (key == "history")
+			return JsonOk(std::string("\"history\":") + (sim.GetCPU().IsHistoryEnabled() ? "true" : "false"));
 		if (key == "fppatch")
 			return JsonOk(std::string("\"fppatch\":") + (sim.IsFPPatchEnabled() ? "true" : "false"));
 		if (key == "stereo")
@@ -2163,6 +2168,15 @@ std::string CmdConfig(ATSimulator& sim, const std::vector<std::string>& tokens) 
 		if (!ParseBoolLiteral(rawVal, v))
 			return JsonError("CONFIG: expected boolean for fastboot");
 		sim.SetFastBootEnabled(v);
+	}
+	else if (key == "history") {
+		// The CPU's instruction history ring, which HISTORY reads: off by
+		// default because recording costs time, on for a run that wants
+		// the last 131072 instructions when something goes wrong.
+		bool v = false;
+		if (!ParseBoolLiteral(rawVal, v))
+			return JsonError("CONFIG: expected boolean for history");
+		sim.GetCPU().SetHistoryEnabled(v);
 	}
 	else if (key == "fppatch") {
 		bool v = false;

--- a/src/AltirraSDL/source/bridge/bridge_server.cpp
+++ b/src/AltirraSDL/source/bridge/bridge_server.cpp
@@ -579,6 +579,15 @@ void Poll(ATSimulator& sim, ATUIState& /*ui*/) {
 	// the second client races into TryAccept() and gets rejected by
 	// the "we already have a client" branch.
 	if (g_state.transport.HasClient()) {
+		// A reply that did not fit the kernel buffer goes out first:
+		// the client is waiting for the rest of it, not typing.
+		if (g_state.transport.HasPendingSend()) {
+			if (g_state.transport.FlushPending() == IoResult::Error) {
+				g_state.transport.DropClient();
+				OnClientDisconnected(sim);
+				return;
+			}
+		}
 		char buf[4096];
 		size_t got = 0;
 		IoResult rr = g_state.transport.Recv(buf, sizeof buf, &got);

--- a/src/AltirraSDL/source/bridge/bridge_transport.cpp
+++ b/src/AltirraSDL/source/bridge/bridge_transport.cpp
@@ -462,6 +462,15 @@ IoResult Transport::SendAll(const void* buf, size_t len) {
 	// Append to any previously-pending tail and try to flush
 	// everything in one go.
 	mPendingSend.append((const char*)buf, len);
+	return FlushPending();
+}
+
+IoResult Transport::FlushPending() {
+	if (BR_IS_INVALID(mClientFd))
+		return IoResult::Error;
+	if (mPendingSend.empty())
+		return IoResult::Ok;
+
 	const char* p = mPendingSend.data();
 	size_t remaining = mPendingSend.size();
 
@@ -478,7 +487,8 @@ IoResult Transport::SendAll(const void* buf, size_t len) {
 		}
 		int e = BR_LAST_ERR();
 		if (BR_WOULDBLOCK(e) || BR_INTR(e)) {
-			// Save the unsent tail; the next SendAll will retry.
+			// Save the unsent tail; the next FlushPending (from
+			// Poll or the next SendAll) will retry.
 			mPendingSend.assign(p, remaining);
 			return IoResult::WouldBlock;
 		}

--- a/src/AltirraSDL/source/bridge/bridge_transport.h
+++ b/src/AltirraSDL/source/bridge/bridge_transport.h
@@ -79,6 +79,14 @@ public:
 	// should try again later (the unsent tail is queued internally).
 	IoResult SendAll(const void* buf, size_t len);
 
+	// Retry the tail SendAll could not fit into the kernel buffer.
+	// A reply bigger than the socket buffer (HISTORY at its full
+	// count is over a megabyte) needs this: the client is blocked
+	// reading the reply, so no further command will arrive to
+	// trigger the retry -- the server's poll loop has to.
+	bool HasPendingSend() const { return !mPendingSend.empty(); }
+	IoResult FlushPending();
+
 	// Drop the active client immediately. Does not affect the
 	// listening socket. Used after Shutdown of the bridge or on
 	// protocol errors that warrant dropping the connection.


### PR DESCRIPTION
The bridge can drive a 65C816 machine but it cannot see one. Three
changes, all in the bridge, independent of #88 (which is the CPU core
and the command line; the two touch `bridge_commands_write.cpp` in
different places, so whichever lands second may want a one-hunk
context merge).

### `REGS` reports the rest of the CPU on a 65C816

`K`, `B`, `D`, `SH`, `AH`, `XH`, `YH` and `E`, added when
`GetCPUMode() == kATCPUMode_65C816`. Without them a native-mode `PC`
or `S` is a 16-bit truncation — code running at `$01:$FF32` reads as
`$FF32`, a stack in `$32xx` as if it were on page one — and the bank a
fault is in, or the direct page a routine is using, cannot be seen at
all.

```
REGS: {'mode': '65C816', 'PC': '$44c0', 'K': '$02', 'B': '$00',
       'D': '$2000', 'S': '$c4', 'SH': '$33', 'AH': '$00',
       'XH': '$d6', 'YH': '$00', 'E': 0, 'flags': '------ZC'}
```

### `CONFIG history <bool>`, and the 65C816's fields in `HISTORY`

Recording is off by default because it costs time, so `HISTORY` on a
fresh emulator returns nothing; `CONFIG history true` turns
`ATCPUEmulator::SetHistoryEnabled` on, and the flag joins the full
`CONFIG` payload beside `debugbrkrun`. Entries then carry `k`, `b`,
`sh`, `e` and `bytes` — the instruction's four bytes — for a 65C816,
which is what makes a history readable when the code is not in bank 0:

```
{'pc': '$44c0', 'k': '$02', 'b': '$00', 'sh': '$33', 'e': 0,
 'bytes': 'adff21f0', 'op': '$ad'}
```

### A fix: a reply larger than the socket buffer never finished

`SendAll` sent as far as the kernel would take and kept the tail for
"the next `SendAll`" — which never came, because the client was
blocked reading the reply and so sent no further command. `HISTORY` at
a few hundred entries is already past a default send buffer, and
`HISTORY 4096` is near a megabyte. `Transport::FlushPending` is that
retry, and `Poll` calls it before it looks for input.

### How it was found, and how it was tested

Writing a headless test suite for a port of GEM to an Atari with a
Rapidus 65C816 accelerator, where the emulator is the only machine
there is. A gate stopped making calls; `REGS` said the PC was `$FF32`
and nothing else. With `K` and the history's `bytes` it was plainly
the IRQ handler, re-entered on every `RTI` because a runaway loop in
the guest had written POKEY's `IRQEN` — eight instructions, over and
over, in bank `$01`.

Built from this branch alone (upstream `main` plus this commit,
`./build.sh --release --system-sdl3`), then exercised over the bridge
against a real native-mode target — gem4xe's test runner on a
SpartaDOS disk, which switches the CPU through the Rapidus's own
register on the way up:

- `REGS` in native mode gives the values above (the runner's far code
  is in bank `$02`, its direct page at `$2000`, its stack in `$33xx`);
- `CONFIG history` queries, sets, reports itself back in the full
  state, and answers `CONFIG: expected boolean for history` to a bad
  value;
- `HISTORY 6` carries the `816` fields; `HISTORY 4096` comes back in
  one reply, 4096 entries and ~970 KB, which is the flush fix.

`PROTOCOL.md` and the Python SDK's docstrings document the new fields
and that recording has to be turned on first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HCRtB54G8FDTrR2JYb34H4
